### PR TITLE
PASS-002-FEAT-FE-AUTH-DOMAIN

### DIFF
--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -1,0 +1,48 @@
+import { axiosInstance } from '@/utils/Auth/axiosInstance';
+import { clearTokenExpiresInfo, refreshTokenOnce } from '@/utils/Auth/tokenRefreshManager';
+
+export const fetchMe = async () => {
+    const { data } = await axiosInstance.get('/api/v1/users/me'); // TODO: Env로 뺄 것
+    return data;
+};
+
+export const socialMe = async () => {
+    const [user, tokenExpiresInfo] = await Promise.all([
+        fetchMe(),
+        refreshTokenOnce(),
+    ]);
+    return { user, tokenExpiresInfo };
+};
+
+export const logout = async () => {
+    try {
+        await axiosInstance.post('/api/v1/auth/logout').catch(() => {}); // TODO: Env로 뺄 것
+        clearTokenExpiresInfo();
+        return true;
+    } catch (error) {
+        console.error('로그아웃 실패', error);
+        return false;
+    }
+};
+
+export const revokeSession = async () => {
+    try {
+        await axiosInstance.post('/api/v1/auth/revoke-session');
+        clearTokenExpiresInfo();
+        return true;
+    } catch (error) {
+        console.error('세션 종료 실패', error);
+        return false;
+    }
+};
+
+export const deleteAccount = async () => {
+    try {
+        await axiosInstance.delete('/api/v1/auth/delete');
+        clearTokenExpiresInfo();
+        return true;
+    } catch (error) {
+        console.error('계정 삭제 실패', error);
+        return false;
+    }
+};

--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/context/Auth/AuthContext';
+
+const PrivateRoute = () => {
+    const { user } = useAuth();
+    const isAuthenticated = user?.id || localStorage.getItem('userId');
+
+    if (!isAuthenticated) {
+        return <Navigate to="/403" replace />;
+    }
+
+    return <Outlet />;
+};
+
+export default PrivateRoute;

--- a/src/context/Auth/AuthContext.tsx
+++ b/src/context/Auth/AuthContext.tsx
@@ -1,0 +1,94 @@
+import { createContext, useContext, useEffect, useState, useCallback, useMemo, ReactNode } from 'react';
+
+export type UserType = {
+    id: string;
+    nickname: string;
+    profileImageUrl: string;
+    githubLogin: string;
+    role: string; // TODO: 나중에 Role 필드 뺄 것.
+};
+
+interface AuthContextType {
+    user: UserType | null;
+    loginUser: (userData: UserType) => void;
+    logoutUser: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const getInitialUser = (): UserType | null => {
+    const storedId = localStorage.getItem('userId');
+    const storedNickname = localStorage.getItem('nickname');
+    const storedGithubLogin = localStorage.getItem('githubLogin');
+    const storedProfileUrl = localStorage.getItem('profileImageUrl');
+    const storedRole = localStorage.getItem('role');
+
+    if (storedId && storedNickname && storedGithubLogin && storedProfileUrl && storedRole) {
+        return {
+            id: storedId,
+            nickname: storedNickname,
+            githubLogin: storedGithubLogin,
+            profileImageUrl: storedProfileUrl,
+            role: storedRole
+        };
+    }
+    return null;
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [user, setUser] = useState<UserType | null>(getInitialUser);
+
+    // 다른 탭에서의 로그인/로그아웃 동기화
+    useEffect(() => {
+        const handleStorageChange = () => {
+            setUser(getInitialUser());
+        };
+        window.addEventListener('storage', handleStorageChange);
+
+        const handleAuthChange = (e: Event) => {
+            const customEvent = e as CustomEvent;
+            setUser(customEvent.detail);
+        };
+        window.addEventListener('auth-change', handleAuthChange);
+
+        return () => {
+            window.removeEventListener('storage', handleStorageChange);
+            window.removeEventListener('auth-change', handleAuthChange);
+        };
+    }, []);
+
+    const loginUser = useCallback((userData: UserType) => {
+        localStorage.setItem('userId', userData.id);
+        localStorage.setItem('nickname', userData.nickname);
+        localStorage.setItem('githubLogin', userData.githubLogin);
+        localStorage.setItem('profileImageUrl', userData.profileImageUrl);
+        localStorage.setItem('role', userData.role);
+
+        setUser(userData);
+        window.dispatchEvent(new CustomEvent('auth-change', { detail: userData }));
+    }, []);
+
+    const logoutUser = useCallback(() => {
+        localStorage.clear();
+        setUser(null);
+        window.dispatchEvent(new CustomEvent('auth-change', { detail: null }));
+    }, []);
+
+    const contextValue = useMemo(() => ({
+        user,
+        loginUser,
+        logoutUser
+    }), [user, loginUser, logoutUser]);
+
+    return (
+        <AuthContext.Provider value={contextValue}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) throw new Error('useAuth must be used within an AuthProvider');
+    return context;
+};

--- a/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { socialMe } from '@/apis/authApi';
+import { useAuth } from '@/context/Auth/AuthContext';
+
+export default function OAuthCallback() {
+    const navigate = useNavigate();
+    const { loginUser } = useAuth();
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const response = await socialMe();
+
+                if (response?.user) {
+                    const userData = {
+                        id: String(response.user.id),
+                        nickname: response.user.nickname || '',
+                        profileImageUrl: response.user.profileImageUrl || '',
+                        githubLogin: response.user.githubLogin || '',
+                        role: response.user.role || 'USER'
+                    };
+
+                    loginUser(userData);
+                    navigate('/profile'); // 로그인 완료 후 프로필로 리다이렉트
+                } else {
+                    throw new Error('사용자 정보를 가져올 수 없습니다.');
+                }
+            } catch (error: any) {
+                console.error('OAuth 콜백 처리 실패:', error);
+                setError(error.message || '로그인 처리 중 오류가 발생했습니다.');
+
+                setTimeout(() => {
+                    navigate('/');
+                }, 2000);
+            }
+        })();
+    }, [navigate, loginUser]);
+
+    if (error) {
+        return (
+            <div className="flex items-center justify-center min-h-screen bg-[#0d0d0f]">
+                <div className="bg-[#16171a] p-8 rounded-lg shadow-lg w-96 text-center border border-white/10">
+                    <p className="text-red-500 mb-4">{error}</p>
+                    <p className="text-zinc-400 text-sm">홈 화면으로 이동합니다...</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-[#0d0d0f]">
+            <div className="bg-[#16171a] p-8 rounded-lg shadow-lg w-96 text-center border border-white/10">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
+                <p className="text-zinc-300">GitHub 로그인 처리 중...</p>
+            </div>
+        </div>
+    );
+}

--- a/src/utils/Auth/axiosInstance.ts
+++ b/src/utils/Auth/axiosInstance.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import { ensureFreshToken, refreshTokenOnce } from './tokenRefreshManager';
+
+export const axiosInstance = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    withCredentials: true, // HTTP-Only 쿠키 사용을 위해 필수
+});
+
+// 요청 인터셉터: API 요청 전 토큰 유효성 검사 및 갱신
+axiosInstance.interceptors.request.use(
+    async (config) => {
+        const requestUrl = String(config.url || '');
+        const isRefreshRequest = requestUrl.includes('/api/v1/auth/refresh'); // TODO: Env로 빼기
+
+        if (!isRefreshRequest) {
+            try {
+                await ensureFreshToken();
+            } catch (error) {
+                // 무시: 리프레시 실패는 응답 인터셉터나 컴포넌트 단에서 처리
+            }
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401/403 에러 시 1회 재시도 로직
+axiosInstance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error?.config;
+        if (!originalRequest) return Promise.reject(error);
+
+        const status = error?.response?.status;
+        const requestUrl = String(originalRequest.url || '');
+        const isRefreshRequest = requestUrl.includes('/api/v1/auth/refresh'); // TODO: Env로 빼기
+        const alreadyRetried = Boolean(originalRequest._retry);
+
+        if (!isRefreshRequest && !alreadyRetried && (status === 401 || status === 403)) {
+            originalRequest._retry = true;
+            try {
+                await refreshTokenOnce();
+                return axiosInstance(originalRequest);
+            } catch (refreshError) {
+                return Promise.reject(refreshError);
+            }
+        }
+        return Promise.reject(error);
+    }
+);

--- a/src/utils/Auth/tokenRefreshManager.ts
+++ b/src/utils/Auth/tokenRefreshManager.ts
@@ -1,0 +1,128 @@
+import axios from 'axios';
+
+const STORAGE_KEYS = {
+    ACCESS_TOKEN_EXPIRES_AT: 'accessTokenExpiresAt',
+    REFRESH_TOKEN_EXPIRES_AT: 'refreshTokenExpiresAt',
+};
+
+const REFRESH_BUFFER_MS = 60 * 1000; // 만료 1분 전
+const MIN_VALIDITY_MS = 15 * 1000; // 최소 유효시간
+const ACTIVITY_THROTTLE_MS = 3000; // 탭 전환 연타 방지 쓰로틀링
+
+let refreshTimerId: number | null = null;
+let refreshPromise: Promise<any> | null = null;
+let lastActivityCheckAt = 0;
+let isInitialized = false;
+
+const getApiBaseUrl = () => import.meta.env.VITE_API_BASE_URL || window.location.origin;
+
+export function saveTokenExpiresInfo(tokenExpiresInfo: { accessTokenExpiresAt?: string, refreshTokenExpiresAt?: string }) {
+    if (!tokenExpiresInfo) return;
+    if (tokenExpiresInfo.accessTokenExpiresAt) {
+        localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN_EXPIRES_AT, tokenExpiresInfo.accessTokenExpiresAt);
+    }
+    if (tokenExpiresInfo.refreshTokenExpiresAt) {
+        localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN_EXPIRES_AT, tokenExpiresInfo.refreshTokenExpiresAt);
+    }
+    scheduleRefreshByExpiry();
+}
+
+export function clearTokenExpiresInfo() {
+    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN_EXPIRES_AT);
+    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN_EXPIRES_AT);
+    if (refreshTimerId) {
+        clearTimeout(refreshTimerId);
+        refreshTimerId = null;
+    }
+}
+
+const getAccessTokenExpiryMs = () => {
+    const expiresAtStr = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN_EXPIRES_AT);
+    if (!expiresAtStr) return null;
+    const parsed = new Date(expiresAtStr);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.getTime();
+};
+
+async function callRefreshApi() {
+    console.log("✅ Refresh Token Called");
+    const { data } = await axios.post(
+        `${getApiBaseUrl()}/api/v1/auth/refresh`,
+        null,
+        { withCredentials: true }
+    );
+    return data;
+}
+
+export async function refreshTokenOnce() {
+    // ✅ Race Condition 방어: 이미 갱신 중이면 기존 Promise 반환
+    if (refreshPromise) return refreshPromise;
+
+    refreshPromise = (async () => {
+        try {
+            const data = await callRefreshApi();
+            saveTokenExpiresInfo(data);
+            return data;
+        } catch (error) {
+            clearTokenExpiresInfo();
+            localStorage.clear();
+            window.dispatchEvent(new Event('storage'));
+            window.dispatchEvent(new CustomEvent('auth-change', { detail: null }));
+            throw error;
+        }
+    })().finally(() => {
+        refreshPromise = null;
+    });
+
+    return refreshPromise;
+}
+
+export async function ensureFreshToken(minValidityMs = MIN_VALIDITY_MS) {
+    const expiresAtMs = getAccessTokenExpiryMs();
+    if (!expiresAtMs) return null;
+
+    const remainingMs = expiresAtMs - Date.now();
+    if (remainingMs > minValidityMs) return null;
+
+    return refreshTokenOnce();
+}
+
+export function scheduleRefreshByExpiry() {
+    if (refreshTimerId) clearTimeout(refreshTimerId);
+
+    const expiresAtMs = getAccessTokenExpiryMs();
+    if (!expiresAtMs) return;
+
+    const delay = Math.max(0, expiresAtMs - Date.now() - REFRESH_BUFFER_MS);
+    refreshTimerId = window.setTimeout(async () => {
+        try {
+            await refreshTokenOnce();
+        } catch (error) {
+            console.error('선제 토큰 갱신 실패:', error);
+        }
+    }, delay);
+}
+
+export function initializeRefreshManager() {
+    if (isInitialized) return;
+    isInitialized = true;
+
+    scheduleRefreshByExpiry();
+
+    const checkOnActivity = () => {
+        const now = Date.now();
+        // 과도한 체크 방지 (3초 쓰로틀링)
+        if (now - lastActivityCheckAt < ACTIVITY_THROTTLE_MS) return;
+        lastActivityCheckAt = now;
+
+        void ensureFreshToken().catch(() => {
+            // 활동 감지 트리거에 의한 에러는 조용히 무시 (화면 에러 방지)
+        });
+    };
+
+    window.addEventListener("focus", checkOnActivity);
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+            checkOnActivity();
+        }
+    });
+}


### PR DESCRIPTION
## 1️⃣. 작업 내용

프론트엔드 인증 도메인 전반을 구현합니다.

- **authApi.ts**: 로그인·로그아웃·회원탈퇴 API 호출 함수
- **AuthContext.tsx**: 전역 인증 상태(유저 정보, 로그인 여부) 관리 Context
- **axiosInstance.ts**: Axios 인스턴스 (baseURL, withCredentials, 요청/응답 인터셉터)
- **tokenRefreshManager.ts**: Access Token 만료 시 자동 갱신 및 재요청 큐 처리
- **PrivateRoute.tsx**: 비인증 접근 시 리다이렉트 처리 라우트 가드
- **OAuthCallback.tsx**: GitHub OAuth2 콜백 처리 및 인증 상태 동기화

## 2️⃣. 테스트 결과

- GitHub OAuth 로그인 → 콜백 → 인증 상태 반영 플로우 수동 테스트 통과
- Access Token 만료 시 자동 갱신 후 원래 요청 재처리 확인

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

해당 없음

## 5️⃣. 리뷰 요구사항 (선택)

- tokenRefreshManager 동시 요청 처리(큐) 방식 리뷰 요청

## 📎 참고 자료 (선택)

해당 없음