### PR TITLE
PASS-010-FIX-CAREER-CATALOG-IMPORT-CASE

### DIFF
--- a/src/data/careerCatalog.ts
+++ b/src/data/careerCatalog.ts
@@ -1,4 +1,4 @@
-import raw from '@/Assets/dataset/career_tables.json';
+import raw from '@/assets/dataset/career_tables.json';
 import { nameUuidFromUtf8String } from '@/utils/nameUuid';
 
 export type CareerTagEnum = 'ROLE' | 'MAJOR' | 'SKILL';


### PR DESCRIPTION
## 1️⃣. 작업 내용

Cloudflare Pages(Linux) 빌드 환경에서 발생하는 import 경로 대소문자 오류를 수정합니다.

- **careerCatalog.ts**: `@/Assets/dataset/career_tables.json` → `@/assets/dataset/career_tables.json`

**원인**: macOS는 대소문자 무감지(case-insensitive) 파일시스템이라 로컬 빌드는 성공하지만, Cloudflare Pages의 Linux 환경은 대소문자 감지(case-sensitive)이므로 `Assets` ≠ `assets` 로 처리되어 모듈을 찾지 못함

## 2️⃣. 테스트 결과

- 로컬 `npm run build` 타입 오류 없이 통과 확인

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

해당 없음

## 5️⃣. 리뷰 요구사항 (선택)

해당 없음

## 📎 참고 자료 (선택)

해당 없음