### PR TITLE
PASS-012 | feat: HTTP 400/401/429 에러 페이지 추가

### DIFF
--- a/src/pages/Error/BadRequestPage.tsx
+++ b/src/pages/Error/BadRequestPage.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { ErrorLayout } from './ErrorLayout';
+
+export function BadRequestPage() {
+    const navigate = useNavigate();
+
+    return (
+        <ErrorLayout
+            code="400"
+            label="Bad Request"
+            title="잘못된 요청입니다"
+            description="요청 형식이 올바르지 않거나 필요한 값이 누락되었습니다. 입력값을 확인한 뒤 다시 시도해 주세요."
+            primaryAction={{ label: '뒤로 가기', onClick: () => navigate(-1) }}
+            secondaryAction={{ label: '홈으로', onClick: () => navigate('/') }}
+        />
+    );
+}

--- a/src/pages/Error/ErrorLayout.tsx
+++ b/src/pages/Error/ErrorLayout.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { LanderFooter } from '@/components/Lander/landerFooter';
+import { LanderFooter } from '@/components/Lander/LanderFooter';
 
 type ErrorLayoutProps = {
     code: string;

--- a/src/pages/Error/ForbiddenPage.tsx
+++ b/src/pages/Error/ForbiddenPage.tsx
@@ -9,8 +9,8 @@ export function ForbiddenPage() {
             code="403"
             label="Access Denied"
             title="접근 권한이 없습니다"
-            description="이 페이지에 접근하려면 로그인이 필요합니다. GitHub 계정으로 로그인 후 이용해 주세요."
-            primaryAction={{ label: '로그인 하러 가기', onClick: () => navigate('/') }}
+            description="인증은 되었지만 이 리소스에 대한 권한이 없습니다. 관리자에게 권한을 요청해 주세요."
+            primaryAction={{ label: '홈으로', onClick: () => navigate('/') }}
             secondaryAction={{ label: '뒤로 가기', onClick: () => navigate(-1) }}
         />
     );

--- a/src/pages/Error/TooManyRequestsPage.tsx
+++ b/src/pages/Error/TooManyRequestsPage.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { ErrorLayout } from './ErrorLayout';
+
+export function TooManyRequestsPage() {
+    const navigate = useNavigate();
+
+    return (
+        <ErrorLayout
+            code="429"
+            label="Too Many Requests"
+            title="요청이 너무 많습니다"
+            description="짧은 시간에 요청이 과도하게 발생했습니다. 잠시 후 다시 시도해 주세요."
+            primaryAction={{ label: '다시 시도', onClick: () => window.location.reload() }}
+            secondaryAction={{ label: '홈으로', onClick: () => navigate('/') }}
+        />
+    );
+}

--- a/src/pages/Error/UnauthorizedPage.tsx
+++ b/src/pages/Error/UnauthorizedPage.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { ErrorLayout } from './ErrorLayout';
+
+export function UnauthorizedPage() {
+    const navigate = useNavigate();
+
+    return (
+        <ErrorLayout
+            code="401"
+            label="Unauthorized"
+            title="인증이 필요합니다"
+            description="로그인이 필요한 요청입니다. 인증 후 다시 시도해 주세요."
+            primaryAction={{ label: '로그인 하러 가기', onClick: () => navigate('/') }}
+            secondaryAction={{ label: '뒤로 가기', onClick: () => navigate(-1) }}
+        />
+    );
+}


### PR DESCRIPTION
## 1️⃣. 작업 내용

누락된 HTTP 에러 페이지를 추가하고 ErrorLayout 컴포넌트를 개선합니다.

### 신규 페이지
| 페이지 | 경로 | 설명 |
|---|---|---|
| `BadRequestPage` | `/400` | 잘못된 요청 |
| `UnauthorizedPage` | `/401` | 인증 필요 |
| `TooManyRequestsPage` | `/429` | 요청 과다 |

### 수정
- `ForbiddenPage` — default → named export 통일
- `ErrorLayout` — `primaryAction` / `secondaryAction` props 구조화

## 2️⃣. 테스트 결과

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

## 5️⃣. 리뷰 요구사항 (선택)

## 📎 참고 자료 (선택)