### PR TITLE
PASS-019 | fix: Footer 문의 섹션 모바일 개행 버그 수정

### DIFF
--- a/src/components/Lander/LanderFooter.tsx
+++ b/src/components/Lander/LanderFooter.tsx
@@ -8,7 +8,7 @@ import {
 
 function renderFooterSegmentRow(segmentList: string[]) {
   return segmentList.map((segment, index) => (
-    <span key={`${segment}-${index}`}>
+    <span key={`${segment}-${index}`} className="footer-segment">
       {index > 0 ? (
         <span className="divider" aria-hidden>
           |

--- a/src/constants/landingPage.ts
+++ b/src/constants/landingPage.ts
@@ -282,7 +282,7 @@ export function getLandingFooterInfoSegments(): LandingFooterInfoSegmentsType {
   ].filter(Boolean);
 
   const contactBody = [phone, email].filter(Boolean).join(' / ');
-  const contactLine = contactBody ? `문의 ${contactBody}` : '';
+  const contactLine = contactBody ? `문의\u00A0${contactBody}` : '';
   const secondLineList = [withAddressLabel(address), contactLine].filter(Boolean);
 
   return { firstLineList, secondLineList };

--- a/src/pages/Lander/landerPage.css
+++ b/src/pages/Lander/landerPage.css
@@ -1065,7 +1065,7 @@
     display: none;
   }
 
-  .footer-info span {
+  .footer-info .footer-segment {
     display: block;
     margin-bottom: 4px;
   }


### PR DESCRIPTION
## Summary
- `문의` 라벨과 전화번호 사이에 NBSP(`\u00A0`) 적용 → 모바일에서 "문의"가 단독 줄로 렌더링되는 문제 해결
- `renderFooterSegmentRow` 외부 `<span>`에 `footer-segment` 클래스 추가
- CSS 셀렉터 `.footer-info span` → `.footer-info .footer-segment` 정밀화 → divider 등 내부 span에 `display:block`이 전파되지 않도록 수정

## Root Cause
`contactLine = "문의 02-1234-5678 / email"` 문자열에서 "문의" 뒤 일반 공백을 브라우저가 줄바꿈 경계로 인식. 모바일에서 `.footer-info span { display: block }` 셀렉터가 모든 하위 span에 적용되어 구조 오염.

## Test plan
- [ ] 모바일 뷰포트(390px)에서 Footer "문의" 섹션 렌더링 확인 — "문의 02-XXX-XXXX" 한 줄 유지
- [ ] 데스크탑에서 Footer 레이아웃 회귀 없음 확인
- [ ] 이메일 값이 없을 때 전화번호만, 전화번호가 없을 때 이메일만 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)