### PR TITLE
PASS-020 | fix: FAQ·프로필·모달 레이아웃 및 전역 스타일 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo/Passfolio_Main_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="format-detection" content="telephone=no, email=no, address=no" />
     <meta
       name="description"
       content="Passfolio — GitHub 연동 기반 AI 포트폴리오 빌더"

--- a/src/components/Profile/TechStackSection.tsx
+++ b/src/components/Profile/TechStackSection.tsx
@@ -61,10 +61,10 @@ export const TechStackSection = ({ roles, majors, skills, className }: TechStack
               key={key}
               className="flex flex-col gap-2 border-l border-white/[0.08] pl-3 sm:pl-4 lg:flex-row lg:items-start lg:gap-2.5 lg:border-l-0 lg:pl-0"
             >
-              <div className="w-auto shrink-0 text-[11px] font-semibold uppercase tracking-widest text-zinc-500 lg:w-[4.75rem] lg:text-left">
-                <span className="block">{label}</span>
+              <div className="flex w-auto shrink-0 items-baseline gap-2 text-[11px] font-semibold uppercase tracking-widest text-zinc-500 lg:block lg:w-[4.75rem] lg:text-left">
+                <span className="lg:block">{label}</span>
                 {chips.length > 0 && (
-                  <span className="mt-0.5 block text-[0.65rem] font-medium tabular-nums normal-case tracking-normal text-zinc-600">
+                  <span className="text-[0.65rem] font-medium tabular-nums normal-case tracking-normal text-zinc-600 lg:mt-0.5 lg:block">
                     {chips.length}개
                   </span>
                 )}

--- a/src/components/Profile/UpdateProfileModal/UpdateProfileModal.tsx
+++ b/src/components/Profile/UpdateProfileModal/UpdateProfileModal.tsx
@@ -14,7 +14,7 @@ export const UpdateProfileModal = ({ open, onClose, userId, onProfileUpdated }: 
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-center justify-center p-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] sm:p-6"
+      className="fixed inset-0 z-[1100] flex items-center justify-center p-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(4.5rem,calc(60px+env(safe-area-inset-top)))] sm:p-6 sm:pt-[max(1rem,env(safe-area-inset-top))]"
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}
@@ -26,7 +26,7 @@ export const UpdateProfileModal = ({ open, onClose, userId, onProfileUpdated }: 
         onClick={onClose}
       />
       <div
-        className="relative z-[201] flex max-h-[min(92dvh,880px)] w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border border-white/[0.12] shadow-[0_16px_64px_-8px_rgba(0,0,0,0.55)]"
+        className="relative z-[1101] flex max-h-[min(92dvh,880px)] w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border border-white/[0.12] shadow-[0_16px_64px_-8px_rgba(0,0,0,0.55)]"
         style={{ background: 'linear-gradient(165deg, rgba(28,28,32,0.98) 0%, rgba(12,12,14,0.99) 100%)' }}
       >
         <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/25 to-transparent" />

--- a/src/pages/Faq/FaqPage.tsx
+++ b/src/pages/Faq/FaqPage.tsx
@@ -41,15 +41,13 @@ export function FaqPage() {
                 className="group rounded-2xl border border-white/[0.09] px-5 py-4 md:px-6 md:py-5 open:shadow-[inset_0_1px_0_rgba(255,255,255,0.09),0_4px_24px_-6px_rgba(0,0,0,0.5)]"
                 style={{ background: 'rgba(18,18,22,0.92)' }}
               >
-                <summary className="cursor-pointer list-none pr-8 text-base font-semibold tracking-tight text-white marker:content-none [&::-webkit-details-marker]:hidden">
-                  <span className="relative block">
-                    {item.question}
-                    <span
-                      className="pointer-events-none absolute right-0 top-1/2 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-full border border-white/[0.1] bg-white/[0.04] text-zinc-400 transition-transform duration-200 group-open:rotate-180"
-                      aria-hidden
-                    >
-                      <i className="fa-solid fa-chevron-down text-[0.65rem]" />
-                    </span>
+                <summary className="flex cursor-pointer list-none items-center gap-4 text-base font-semibold tracking-tight text-white marker:content-none [&::-webkit-details-marker]:hidden">
+                  <span className="min-w-0 flex-1">{item.question}</span>
+                  <span
+                    className="pointer-events-none inline-flex size-6 shrink-0 items-center justify-center rounded-full border border-white/[0.1] bg-white/[0.04] text-zinc-400 transition-transform duration-200 group-open:rotate-180"
+                    aria-hidden
+                  >
+                    <i className="fa-solid fa-chevron-down text-[0.65rem]" />
                   </span>
                 </summary>
                 <div className="mt-4 space-y-3 border-t border-white/[0.06] pt-4">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,6 +53,7 @@
 
   a {
     color: inherit;
+    text-decoration: none;
   }
 
   button {


### PR DESCRIPTION
## 1️⃣. 작업 내용

> 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요. (이미지 첨부 가능)

- `index.html`: WebKit format-detection(전화·이메일·주소 자동 링크) 비활성화
- `global.css`: 전역 `a` 태그 기본 밑줄 제거
- `FaqPage`: FAQ summary를 flex로 정리해 긴 질문 줄바꿈 시에도 chevron 정렬 유지
- `TechStackSection`: 좁은 화면에서 기술 스택 라벨·개수 한 줄 정렬, lg 이상은 기존 열 레이아웃 유지
- `UpdateProfileModal`: 모달 z-index를 헤더 위로 올리고, 모바일 상단 safe-area·노치 대비 패딩 조정

## 2️⃣. 테스트 결과

| 항목 | 결과 |
|------|------|
| `npm run build` (`tsc -b && vite build`) | 성공 |

**수동 확인(권장)**: FAQ 긴 질문, 프로필 기술 스택 라벨(모바일), 프로필 수정 모달과 헤더 겹침·상단 여백

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

(해당 없음)

## 5️⃣. 리뷰 요구사항 (선택)

모바일 Safari/Chrome에서 FAQ·프로필 수정 모달만 한 번 확인해 주시면 됩니다.

## 📎 참고 자료 (선택)

- 브랜치: `PASS-020-FIX-LAYOUT-ISSUE`

Made with [Cursor](https://cursor.com)