### PR TITLE
fix: 배포환경 Chrome에서의 HeaderComponent css 이슈 개선

### DIFF
--- a/src/pages/Lander/landerPage.css
+++ b/src/pages/Lander/landerPage.css
@@ -78,6 +78,7 @@
     -webkit-backdrop-filter: blur(32px) saturate(200%);
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
     box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.7), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    will-change: backdrop-filter;
   }
 
   .nav-container,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,7 @@
 
   html {
     scroll-behavior: smooth;
+    overflow-x: hidden;
   }
 
   body {
@@ -48,7 +49,6 @@
     -moz-osx-font-smoothing: grayscale;
     word-break: keep-all;
     overflow-wrap: break-word;
-    overflow-x: hidden;
   }
 
   a {


### PR DESCRIPTION
## 1️⃣. 작업 내용

overflow-x: hidden을 body → html로 이동

Chrome은 body { overflow-x: hidden }이 있을 때 body를 새로운 BFC(Block Formatting Context)로 처리하면서, position: fixed 자식요소의 backdrop sampling 경로를 차단

html에 설정하면 뷰포트 overflow 차단 효과는 동일하지만, html은 position: fixed 요소의 containing block을 만들지 않으므로 backdrop sampling 정상 동작 기대

nav.scrolled에 will-change: backdrop-filter 추가 — Chrome 컴포지터가 blur 레이어를 스크롤 전에 미리 준비하도록 힌트 제공

#23 

## 2️⃣. 테스트 결과

배포환경의 Chrome 이라는 특수 상황에서 발생한 이슈인만큼, 일단 배포를 해봐야 함

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 5️⃣. 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요