### PR TITLE
feat/fix: NONSTOP 업로드 모달 + fileId 전송 + 포폴 핸드오프 재시도 UI

### DIFF
--- a/src/api/Http/apiEndpoints.ts
+++ b/src/api/Http/apiEndpoints.ts
@@ -49,6 +49,7 @@ export const API_ENDPOINTS = {
         start: '/api/v1/project-analysis/start',
         subscribe: '/api/v1/project-analysis/subscribe', // SSE
         batchStatus: (batchId: string) => `/api/v1/project-analysis/batch/${batchId}`, // 본인 배치 상태(진행중 페이지)
+        retryPortfolio: (batchId: string) => `/api/v1/project-analysis/batch/${batchId}/portfolio`, // 포폴 핸드오프 수동 재시도
         report: (analysisId: string) => `/api/v1/project-analysis/${analysisId}/report`, // 본인 단건 리포트(BE가 CDN JSON 프록시)
         history: '/api/v1/project-analysis/history', // 본인 분석 이력(최근순)
     },

--- a/src/api/ProjectAnalysis/projectAnalysisApi.ts
+++ b/src/api/ProjectAnalysis/projectAnalysisApi.ts
@@ -26,15 +26,18 @@ export const getRepoPrecheckStatus = async (): Promise<PrecheckItemType[]> => {
     return Array.isArray(data) ? data : [];
 };
 
-// 분석 시작(AVAILABLE repo, ≤3). mode 기본 NONSTOP. phone(선택)=완료 SMS 수신 번호(DB 미저장·transient).
+// 분석 시작(AVAILABLE repo, ≤3). mode 기본 NONSTOP. phone(선택)=완료 SMS(transient).
+// NONSTOP 포트폴리오: pdfUrl(업로드 PDF CDN URL) + portfolioPurpose(EDIT|GENERATE).
 export const postStartAnalysis = async (
     repoUrlList: string[],
     mode?: string,
     phone?: string,
+    pdfUrl?: string,
+    portfolioPurpose?: string,
 ): Promise<AnalysisStartResponseType> => {
     const { data } = await axiosInstance.post<AnalysisStartResponseType>(
         API_ENDPOINTS.projectAnalysis.start,
-        { repoUrls: repoUrlList, mode, phone },
+        { repoUrls: repoUrlList, mode, phone, pdfUrl, portfolioPurpose },
     );
     return data;
 };

--- a/src/api/ProjectAnalysis/projectAnalysisApi.ts
+++ b/src/api/ProjectAnalysis/projectAnalysisApi.ts
@@ -27,19 +27,25 @@ export const getRepoPrecheckStatus = async (): Promise<PrecheckItemType[]> => {
 };
 
 // 분석 시작(AVAILABLE repo, ≤3). mode 기본 NONSTOP. phone(선택)=완료 SMS(transient).
-// NONSTOP 포트폴리오: pdfUrl(업로드 PDF CDN URL) + portfolioPurpose(EDIT|GENERATE).
+// NONSTOP 포트폴리오: fileId(업로드 PDF 파일 ID — 소유권 검증·CDN URL 생성은 서버) + portfolioPurpose(EDIT|GENERATE).
 export const postStartAnalysis = async (
     repoUrlList: string[],
     mode?: string,
     phone?: string,
-    pdfUrl?: string,
+    fileId?: number,
     portfolioPurpose?: string,
 ): Promise<AnalysisStartResponseType> => {
     const { data } = await axiosInstance.post<AnalysisStartResponseType>(
         API_ENDPOINTS.projectAnalysis.start,
-        { repoUrls: repoUrlList, mode, phone, pdfUrl, portfolioPurpose },
+        { repoUrls: repoUrlList, mode, phone, fileId, portfolioPurpose },
     );
     return data;
+};
+
+// NONSTOP 포폴 핸드오프 수동 재시도(자동 핸드오프가 FastAPI 장애로 실패한 본인 배치 복구).
+// 성공 후 getUserBatchStatus로 새 portfolioJobId를 읽는다.
+export const retryPortfolioHandoff = async (batchId: string): Promise<void> => {
+    await axiosInstance.post(API_ENDPOINTS.projectAnalysis.retryPortfolio(batchId));
 };
 
 // 본인 배치의 repo별 상태(진행중 페이지 초기 로드 + 안전 폴링). 타인 batch는 BE에서 차단.

--- a/src/components/Profile/AnalysisStartModal.tsx
+++ b/src/components/Profile/AnalysisStartModal.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { postStartAnalysis } from '@/api/ProjectAnalysis/projectAnalysisApi';
+import { uploadFileToS3 } from '@/utils/Article/uploadToS3';
 import type { AnalysisModeType } from '@/types/userProjectAnalysis.type';
+import type { DocumentTypeValue, ActionTypeValue } from '@/types/file.type';
 
 type AnalysisStartModalProps = {
     isOpen: boolean;
@@ -12,6 +14,34 @@ type AnalysisStartModalProps = {
 const MODE_OPTIONS: { value: AnalysisModeType; label: string; description: string }[] = [
     { value: 'NONSTOP', label: '논스톱', description: '분석 후 포트폴리오까지 자동 생성합니다.' },
     { value: 'STEP', label: '단계별', description: '분석만 수행하고 결과를 확인합니다.' },
+];
+
+// NONSTOP 포트폴리오 목적 — 결과물이 포트폴리오인 2가지(자소서·포폴 동시 업로드 불가).
+type PortfolioPurpose = 'EDIT' | 'GENERATE';
+const PURPOSE_OPTIONS: {
+    value: PortfolioPurpose;
+    label: string;
+    description: string;
+    documentType: DocumentTypeValue;
+    actionType: ActionTypeValue;
+    fileLabel: string;
+}[] = [
+    {
+        value: 'EDIT',
+        label: '기존 포트폴리오 개선',
+        description: '업로드한 포트폴리오 PDF를 분석 결과로 보강·개선합니다.',
+        documentType: 'PORTFOLIO',
+        actionType: 'EDIT',
+        fileLabel: '포트폴리오 PDF',
+    },
+    {
+        value: 'GENERATE',
+        label: '자기소개서로 포트폴리오 생성',
+        description: '업로드한 자기소개서 PDF와 분석 결과로 포트폴리오를 생성합니다.',
+        documentType: 'COVER_LETTER',
+        actionType: 'GENERATE',
+        fileLabel: '자기소개서 PDF',
+    },
 ];
 
 const shortenRepoUrl = (repoUrl: string): string =>
@@ -27,7 +57,6 @@ const normalizePhone = (raw: string): string | null => {
     }
     const digits = trimmed.replace(/\D/g, '');
     if (digits === '') return null;
-    // 국내 번호(0으로 시작) → +82로 변환. 그 외는 그대로 +붙임.
     return digits.startsWith('0') ? `+82${digits.slice(1)}` : `+${digits}`;
 };
 
@@ -36,34 +65,78 @@ const isValidE164 = (e164: string): boolean => /^\+[1-9]\d{7,14}$/.test(e164);
 export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartModalProps) => {
     const navigate = useNavigate();
     const [mode, setMode] = useState<AnalysisModeType>('NONSTOP');
+    const [purpose, setPurpose] = useState<PortfolioPurpose>('EDIT');
+    const [file, setFile] = useState<File | null>(null);
+    const [uploadProgress, setUploadProgress] = useState<number>(0);
+    const [isUploading, setIsUploading] = useState<boolean>(false);
     const [smsOptIn, setSmsOptIn] = useState<boolean>(false);
     const [phone, setPhone] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
 
+    const purposeMeta = useMemo(() => PURPOSE_OPTIONS.find((p) => p.value === purpose)!, [purpose]);
     const normalizedPhone = useMemo(() => normalizePhone(phone), [phone]);
     const phoneInvalid = smsOptIn && (normalizedPhone === null || !isValidE164(normalizedPhone));
 
+    const busy = isSubmitting || isUploading;
+
     const handleSubmit = useCallback(async () => {
-        if (repoUrls.length === 0 || isSubmitting) return;
+        if (repoUrls.length === 0 || busy) return;
         if (smsOptIn && phoneInvalid) {
             setErrorMessage('휴대폰 번호 형식을 확인해주세요. (예: 010-1234-5678)');
             return;
         }
-        setIsSubmitting(true);
+        // NONSTOP은 포트폴리오용 PDF 업로드 필수.
+        if (mode === 'NONSTOP' && !file) {
+            setErrorMessage(`${purposeMeta.fileLabel}를 업로드해주세요.`);
+            return;
+        }
         setErrorMessage(null);
+
+        let pdfUrl: string | undefined;
+        let portfolioPurpose: string | undefined;
+        try {
+            if (mode === 'NONSTOP' && file) {
+                setIsUploading(true);
+                setUploadProgress(0);
+                abortRef.current = new AbortController();
+                const result = await uploadFileToS3(file, {
+                    signal: abortRef.current.signal,
+                    onProgress: setUploadProgress,
+                    documentType: purposeMeta.documentType,
+                    actionType: purposeMeta.actionType,
+                });
+                pdfUrl = result.cdnUrl;
+                portfolioPurpose = purpose;
+                setIsUploading(false);
+            }
+        } catch {
+            setIsUploading(false);
+            setErrorMessage('파일 업로드에 실패했습니다. 잠시 후 다시 시도해주세요.');
+            return;
+        }
+
+        setIsSubmitting(true);
         try {
             const res = await postStartAnalysis(
                 repoUrls,
                 mode,
                 smsOptIn && normalizedPhone ? normalizedPhone : undefined,
+                pdfUrl,
+                portfolioPurpose,
             );
             navigate(`/analysis/${res.batchId}`);
         } catch {
             setErrorMessage('분석 시작에 실패했습니다. 잠시 후 다시 시도해주세요.');
             setIsSubmitting(false);
         }
-    }, [repoUrls, isSubmitting, smsOptIn, phoneInvalid, mode, normalizedPhone, navigate]);
+    }, [repoUrls, busy, smsOptIn, phoneInvalid, mode, file, purpose, purposeMeta, normalizedPhone, navigate]);
+
+    const handleClose = useCallback(() => {
+        abortRef.current?.abort();
+        onClose();
+    }, [onClose]);
 
     if (!isOpen) return null;
 
@@ -71,13 +144,13 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
         <div
             className="fixed inset-0 z-[3000] flex items-end justify-center px-0 sm:items-center sm:px-4"
             style={{ background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(6px)' }}
-            onClick={onClose}
+            onClick={handleClose}
         >
             <div
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="analysis-start-title"
-                className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl sm:max-w-[440px] sm:rounded-2xl"
+                className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl sm:max-w-[460px] sm:rounded-2xl"
                 style={{
                     background: 'linear-gradient(160deg, rgba(28,28,32,0.97) 0%, rgba(15,16,18,0.99) 100%)',
                     backdropFilter: 'blur(40px) saturate(180%)',
@@ -91,9 +164,7 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                     <h2 id="analysis-start-title" className="text-base font-semibold text-white">
                         프로젝트 분석 시작
                     </h2>
-                    <p className="mt-1 text-sm text-zinc-500">
-                        선택한 저장소 {repoUrls.length}개를 분석합니다.
-                    </p>
+                    <p className="mt-1 text-sm text-zinc-500">선택한 저장소 {repoUrls.length}개를 분석합니다.</p>
 
                     {/* 분석 대상 목록 */}
                     <ul className="mt-4 flex list-none flex-col gap-1.5 p-0">
@@ -118,9 +189,7 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                                     <label
                                         key={option.value}
                                         className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-colors ${
-                                            isActive
-                                                ? 'border-white/25 bg-white/[0.08]'
-                                                : 'border-white/[0.08] bg-[#101114]/70 hover:border-white/14'
+                                            isActive ? 'border-white/25 bg-white/[0.08]' : 'border-white/[0.08] bg-[#101114]/70 hover:border-white/14'
                                         }`}
                                     >
                                         <input
@@ -141,6 +210,69 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                         </div>
                     </fieldset>
 
+                    {/* NONSTOP: 포트폴리오 목적 + 파일 업로드 (자소서·포폴 동시 불가) */}
+                    {mode === 'NONSTOP' && (
+                        <div className="mt-5 rounded-xl border border-white/[0.08] bg-[#101114]/50 p-4">
+                            <p className="text-sm font-medium text-zinc-300">포트폴리오 생성 방식</p>
+                            <div className="mt-2 flex flex-col gap-2">
+                                {PURPOSE_OPTIONS.map((option) => {
+                                    const isActive = option.value === purpose;
+                                    return (
+                                        <label
+                                            key={option.value}
+                                            className={`flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors ${
+                                                isActive ? 'border-emerald-400/30 bg-emerald-400/[0.08]' : 'border-white/[0.08] hover:border-white/14'
+                                            }`}
+                                        >
+                                            <input
+                                                type="radio"
+                                                name="portfolio-purpose"
+                                                value={option.value}
+                                                checked={isActive}
+                                                onChange={() => {
+                                                    setPurpose(option.value);
+                                                    setFile(null); // 목적 바뀌면 파일 종류가 달라지므로 리셋
+                                                    setErrorMessage(null);
+                                                }}
+                                                className="mt-0.5 h-4 w-4 shrink-0 accent-emerald-400"
+                                            />
+                                            <span className="min-w-0">
+                                                <span className="block text-sm font-medium text-white">{option.label}</span>
+                                                <span className="mt-0.5 block text-xs text-zinc-500">{option.description}</span>
+                                            </span>
+                                        </label>
+                                    );
+                                })}
+                            </div>
+
+                            {/* 파일 업로드 (목적에 맞는 1개) */}
+                            <div className="mt-3">
+                                <label className="block text-xs font-medium text-zinc-400">
+                                    {purposeMeta.fileLabel} 업로드 <span className="text-red-400">*</span>
+                                </label>
+                                <input
+                                    type="file"
+                                    accept="application/pdf"
+                                    onChange={(e) => {
+                                        setFile(e.target.files?.[0] ?? null);
+                                        setErrorMessage(null);
+                                    }}
+                                    className="mt-1.5 block w-full text-xs text-zinc-400 file:mr-3 file:rounded-lg file:border-0 file:bg-white/[0.10] file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-white hover:file:bg-white/[0.16]"
+                                />
+                                {file && <p className="mt-1.5 truncate text-xs text-zinc-500">{file.name}</p>}
+                                {isUploading && (
+                                    <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/[0.06]">
+                                        <div
+                                            className="h-full rounded-full bg-emerald-400/70 transition-[width] duration-200"
+                                            style={{ width: `${uploadProgress}%` }}
+                                        />
+                                    </div>
+                                )}
+                                <p className="mt-1.5 text-xs text-zinc-600">PDF만 업로드 가능합니다. (자소서와 포트폴리오를 동시에 올릴 수 없습니다.)</p>
+                            </div>
+                        </div>
+                    )}
+
                     {/* SMS 수신 */}
                     <div className="mt-5">
                         <label className="flex cursor-pointer items-center gap-3 text-sm text-zinc-300">
@@ -157,9 +289,7 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                         </label>
                         {smsOptIn && (
                             <div className="mt-2">
-                                <label htmlFor="analysis-phone" className="sr-only">
-                                    휴대폰 번호
-                                </label>
+                                <label htmlFor="analysis-phone" className="sr-only">휴대폰 번호</label>
                                 <input
                                     id="analysis-phone"
                                     type="tel"
@@ -189,8 +319,8 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                     <div className="mt-6 flex gap-3">
                         <button
                             type="button"
-                            onClick={onClose}
-                            disabled={isSubmitting}
+                            onClick={handleClose}
+                            disabled={busy}
                             className="flex-1 rounded-xl border border-white/[0.08] py-2.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-white/[0.06] hover:text-white disabled:opacity-40"
                         >
                             취소
@@ -198,10 +328,10 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                         <button
                             type="button"
                             onClick={handleSubmit}
-                            disabled={isSubmitting || repoUrls.length === 0}
+                            disabled={busy || repoUrls.length === 0}
                             className="flex-1 rounded-xl border border-emerald-400/30 bg-emerald-400/15 py-2.5 text-sm font-medium text-emerald-100 transition-colors hover:bg-emerald-400/25 disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                            {isSubmitting ? '시작 중…' : '분석 시작'}
+                            {isUploading ? '업로드 중…' : isSubmitting ? '시작 중…' : '분석 시작'}
                         </button>
                     </div>
                 </div>

--- a/src/components/Profile/AnalysisStartModal.tsx
+++ b/src/components/Profile/AnalysisStartModal.tsx
@@ -94,7 +94,7 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
         }
         setErrorMessage(null);
 
-        let pdfUrl: string | undefined;
+        let fileId: number | undefined;
         let portfolioPurpose: string | undefined;
         try {
             if (mode === 'NONSTOP' && file) {
@@ -107,7 +107,8 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                     documentType: purposeMeta.documentType,
                     actionType: purposeMeta.actionType,
                 });
-                pdfUrl = result.cdnUrl;
+                // 원시 CDN URL이 아니라 fileId를 전달 — 소유권 검증·URL 생성은 서버(IDOR/SSRF 차단).
+                fileId = result.fileId;
                 portfolioPurpose = purpose;
                 setIsUploading(false);
             }
@@ -123,7 +124,7 @@ export const AnalysisStartModal = ({ isOpen, repoUrls, onClose }: AnalysisStartM
                 repoUrls,
                 mode,
                 smsOptIn && normalizedPhone ? normalizedPhone : undefined,
-                pdfUrl,
+                fileId,
                 portfolioPurpose,
             );
             navigate(`/analysis/${res.batchId}`);

--- a/src/components/Profile/ProjectAnalysisSection.tsx
+++ b/src/components/Profile/ProjectAnalysisSection.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { fetchGitHubRepos } from '@/api/GitHub/githubApi';
 import type { GitHubRepoItemType, GitHubRepoType } from '@/api/GitHub/githubApi';
 import { useRepoPrecheck } from '@/hooks/useRepoPrecheck';
@@ -62,7 +63,20 @@ export const ProjectAnalysisSection = () => {
     const [filter, setFilter] = useState<FilterType>('all');
     const [isDispatching, setIsDispatching] = useState<boolean>(false);
     const [isStartModalOpen, setIsStartModalOpen] = useState<boolean>(false);
-    const [sectionTab, setSectionTab] = useState<SectionTabType>('analyze');
+
+    // 분석서 페이지 등에서 ?tab=history 로 진입 시 분석 이력 탭을 열고 해당 위치로 이동한다.
+    const [searchParams, setSearchParams] = useSearchParams();
+    const isHistoryEntry = searchParams.get('tab') === 'history';
+    const [sectionTab, setSectionTab] = useState<SectionTabType>(isHistoryEntry ? 'history' : 'analyze');
+    const sectionRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+        if (!isHistoryEntry) return;
+        sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        const next = new URLSearchParams(searchParams);
+        next.delete('tab');
+        setSearchParams(next, { replace: true });
+    }, [isHistoryEntry, searchParams, setSearchParams]);
 
     const { statusMap, startPrecheck, errorMessage } = useRepoPrecheck();
 
@@ -164,8 +178,9 @@ export const ProjectAnalysisSection = () => {
 
     return (
         <section
+            ref={sectionRef}
             aria-labelledby="project-analysis-heading"
-            className="rounded-2xl border border-white/[0.08] bg-[#141518]/90 p-5 sm:p-6"
+            className="scroll-mt-24 rounded-2xl border border-white/[0.08] bg-[#141518]/90 p-5 sm:p-6"
         >
             <h2 id="project-analysis-heading" className="text-lg font-semibold text-white">
                 프로젝트 분석

--- a/src/hooks/useAnalysisProgress.ts
+++ b/src/hooks/useAnalysisProgress.ts
@@ -33,6 +33,7 @@ export type UseAnalysisProgressReturnType = {
     isLoading: boolean;
     errorMessage: string | null;
     portfolioJob: PortfolioJobStateType | null; // NONSTOP 포폴 생성 작업(없으면 null)
+    refresh: () => Promise<void>; // 배치 상태 재조회(예: 포폴 핸드오프 재시도 후 portfolioJobId 반영)
 };
 
 const toAnalysisStatus = (raw: string): AnalysisStatusType =>
@@ -205,5 +206,5 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
         };
     }, [portfolioJobId]);
 
-    return { status, isLoading, errorMessage, portfolioJob };
+    return { status, isLoading, errorMessage, portfolioJob, refresh };
 }

--- a/src/hooks/useAnalysisProgress.ts
+++ b/src/hooks/useAnalysisProgress.ts
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getUserBatchStatus } from '@/api/ProjectAnalysis/projectAnalysisApi';
+import { getAiJobStatus, type AiJobStatus } from '@/api/AiJob/aiJobApi';
 import { API_ENDPOINTS } from '@/api/Http/apiEndpoints';
 import type {
     AnalysisBatchStatusType,
     AnalysisStatusType,
 } from '@/types/userProjectAnalysis.type';
+
+export type PortfolioJobStateType = {
+    status: AiJobStatus; // PENDING | DONE | ERROR
+    pdfUrl: string | null;
+    errorMessage: string | null;
+};
 
 // 개별 repo 완료 SSE(PROJECT_ANALYSIS_STATUS) — 종료(DONE/FAILED) 시에만 푸시.
 const SSE_ANALYSIS_EVENT = 'PROJECT_ANALYSIS_STATUS';
@@ -25,6 +32,7 @@ export type UseAnalysisProgressReturnType = {
     status: AnalysisBatchStatusType | null;
     isLoading: boolean;
     errorMessage: string | null;
+    portfolioJob: PortfolioJobStateType | null; // NONSTOP 포폴 생성 작업(없으면 null)
 };
 
 const toAnalysisStatus = (raw: string): AnalysisStatusType =>
@@ -40,6 +48,7 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
     const [status, setStatus] = useState<AnalysisBatchStatusType | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [portfolioJob, setPortfolioJob] = useState<PortfolioJobStateType | null>(null);
 
     const statusRef = useRef<AnalysisBatchStatusType | null>(null);
     statusRef.current = status;
@@ -169,5 +178,32 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
     // 언마운트 시 폴링 정리
     useEffect(() => clearPoll, [clearPoll]);
 
-    return { status, isLoading, errorMessage };
+    // NONSTOP 포폴 작업 폴링(batch status에 portfolioJobId가 잡히면) — DONE/ERROR까지 4초 주기.
+    const portfolioJobId = status?.portfolioJobId ?? null;
+    useEffect(() => {
+        if (!portfolioJobId) {
+            setPortfolioJob(null);
+            return;
+        }
+        let cancelled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const poll = async () => {
+            try {
+                const j = await getAiJobStatus(portfolioJobId);
+                if (cancelled) return;
+                setPortfolioJob({ status: j.status, pdfUrl: j.outputPdfS3Url, errorMessage: j.errorMessage });
+                if (j.status === 'DONE' || j.status === 'ERROR') return; // 종료 → 폴링 중지
+            } catch {
+                /* 일시 오류 무시, 다음 폴링에서 재시도 */
+            }
+            if (!cancelled) timer = setTimeout(poll, SAFETY_POLL_MS);
+        };
+        void poll();
+        return () => {
+            cancelled = true;
+            if (timer) clearTimeout(timer);
+        };
+    }, [portfolioJobId]);
+
+    return { status, isLoading, errorMessage, portfolioJob };
 }

--- a/src/pages/Analysis/AnalysisProgressPage.tsx
+++ b/src/pages/Analysis/AnalysisProgressPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { LanderFooter } from '@/components/Lander/LanderFooter';
 import { useAnalysisProgress } from '@/hooks/useAnalysisProgress';
+import { retryPortfolioHandoff } from '@/api/ProjectAnalysis/projectAnalysisApi';
 import type { AnalysisStatusType } from '@/types/userProjectAnalysis.type';
 import '@/pages/Lander/landerPage.css';
 
@@ -45,10 +46,27 @@ const MetricCounter = ({ label, value, accentClassName }: { label: string; value
 
 export const AnalysisProgressPage = () => {
     const { batchId } = useParams<{ batchId: string }>();
-    const { status, isLoading, errorMessage, portfolioJob } = useAnalysisProgress(batchId);
+    const { status, isLoading, errorMessage, portfolioJob, refresh } = useAnalysisProgress(batchId);
     const [nowMs, setNowMs] = useState<number>(() => Date.now());
+    const [isRetrying, setIsRetrying] = useState<boolean>(false);
+    const [retryError, setRetryError] = useState<string | null>(null);
 
     const isRunning = status != null && !status.allTerminal;
+
+    // 자동 핸드오프가 실패한 배치의 포폴 생성 수동 재시도 → 성공 시 새 portfolioJobId를 재조회로 반영.
+    const handleRetryPortfolio = useCallback(async () => {
+        if (!batchId || isRetrying) return;
+        setIsRetrying(true);
+        setRetryError(null);
+        try {
+            await retryPortfolioHandoff(batchId);
+            await refresh();
+        } catch {
+            setRetryError('포트폴리오 생성 재시도에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        } finally {
+            setIsRetrying(false);
+        }
+    }, [batchId, isRetrying, refresh]);
 
     // 진행 중에는 1초 틱으로 경과 시간을 부드럽게 갱신.
     useEffect(() => {
@@ -221,6 +239,25 @@ export const AnalysisProgressPage = () => {
                                         포트폴리오 생성에 실패했습니다.{portfolioJob.errorMessage ? ` (${portfolioJob.errorMessage})` : ''}
                                     </p>
                                 )}
+                            </div>
+                        )}
+
+                        {/* NONSTOP 포폴 자동 핸드오프 실패 → 수동 재시도(portfolioJobId 없고 retryable일 때만) */}
+                        {status.portfolioJobId == null && status.portfolioRetryable && (
+                            <div className="mt-5 rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-4">
+                                <p className="text-sm font-semibold text-amber-100">포트폴리오 생성 시작에 실패했습니다</p>
+                                <p className="mt-1 text-sm text-amber-200/80">
+                                    분석은 완료됐지만 포트폴리오 생성 요청이 시작되지 못했습니다. 아래 버튼으로 다시 시도해주세요.
+                                </p>
+                                <button
+                                    type="button"
+                                    onClick={handleRetryPortfolio}
+                                    disabled={isRetrying}
+                                    className="mt-3 inline-flex items-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/15 px-4 py-2 text-sm font-medium text-amber-100 transition-colors hover:bg-amber-400/25 disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                    {isRetrying ? '재시도 중…' : '포트폴리오 생성 다시 시도'}
+                                </button>
+                                {retryError && <p className="mt-2 text-sm text-red-300/90">{retryError}</p>}
                             </div>
                         )}
                     </section>

--- a/src/pages/Analysis/AnalysisProgressPage.tsx
+++ b/src/pages/Analysis/AnalysisProgressPage.tsx
@@ -45,7 +45,7 @@ const MetricCounter = ({ label, value, accentClassName }: { label: string; value
 
 export const AnalysisProgressPage = () => {
     const { batchId } = useParams<{ batchId: string }>();
-    const { status, isLoading, errorMessage } = useAnalysisProgress(batchId);
+    const { status, isLoading, errorMessage, portfolioJob } = useAnalysisProgress(batchId);
     const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
     const isRunning = status != null && !status.allTerminal;
@@ -192,6 +192,36 @@ export const AnalysisProgressPage = () => {
                             <p className="mt-5 rounded-xl border border-white/[0.08] bg-[#101114]/70 px-4 py-3 text-sm text-zinc-300">
                                 분석 완료 · 총 {total}개 · 완료 {counts.done} · 실패 {counts.failed}
                             </p>
+                        )}
+
+                        {/* NONSTOP 포트폴리오 생성(portfolioJobId가 있을 때만) */}
+                        {status.portfolioJobId != null && (
+                            <div className="mt-5 rounded-xl border border-white/[0.08] bg-[#101114]/70 px-4 py-4">
+                                <div className="flex items-center justify-between gap-2">
+                                    <span className="text-sm font-semibold text-white">포트폴리오 생성</span>
+                                    <span className="text-xs text-zinc-500">
+                                        {portfolioJob?.status === 'DONE' ? '완료' : portfolioJob?.status === 'ERROR' ? '실패' : '생성 중…'}
+                                    </span>
+                                </div>
+                                {(!portfolioJob || portfolioJob.status === 'PENDING') && (
+                                    <p className="mt-2 text-sm text-zinc-400">분석 결과로 포트폴리오를 생성하고 있습니다. 완료되면 여기에 표시됩니다.</p>
+                                )}
+                                {portfolioJob?.status === 'DONE' && portfolioJob.pdfUrl && (
+                                    <a
+                                        href={portfolioJob.pdfUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-400/30 bg-emerald-400/15 px-4 py-2 text-sm font-medium text-emerald-100 transition-colors hover:bg-emerald-400/25"
+                                    >
+                                        포트폴리오 PDF 보기
+                                    </a>
+                                )}
+                                {portfolioJob?.status === 'ERROR' && (
+                                    <p className="mt-2 text-sm text-red-300/90">
+                                        포트폴리오 생성에 실패했습니다.{portfolioJob.errorMessage ? ` (${portfolioJob.errorMessage})` : ''}
+                                    </p>
+                                )}
+                            </div>
                         )}
                     </section>
                 )}

--- a/src/pages/Analysis/AnalysisReportPage.tsx
+++ b/src/pages/Analysis/AnalysisReportPage.tsx
@@ -30,6 +30,9 @@ const ICONS: Record<string, ReactNode> = {
     users: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><circle cx="9" cy="8" r="3.2" /><path d="M3.5 20a5.5 5.5 0 0 1 11 0M16 5.2a3.2 3.2 0 0 1 0 5.6M17.5 14.4A5.5 5.5 0 0 1 21 20" /></svg>,
 };
 
+/** 돌아가기 → 프로필의 프로젝트 분석 탭, 분석 이력 위치 */
+const PROFILE_ANALYSIS_HISTORY_PATH = '/profile?section=project-analysis&tab=history';
+
 const CAT_ORDER = ['Language', 'Framework', 'Database', 'Infrastructure', 'Build·Tooling', 'Library'] as const;
 const fmtDate = (s: string): string => s.replace(/-/g, '.');
 const fmtNum = (n: number): string => n.toLocaleString('en-US');
@@ -517,7 +520,7 @@ export const AnalysisReportPage = () => {
     return (
         <div className="analysis-report">
             <div className="ar-wrap">
-                <Link to={batchId ? `/analysis/${batchId}` : '/profile'} className="ar-back">{ICONS.arrow} 돌아가기</Link>
+                <Link to={PROFILE_ANALYSIS_HISTORY_PATH} className="ar-back">{ICONS.arrow} 돌아가기</Link>
                 <div className="ar-topbar">
                     <div>
                         <h1 className="ar-title">프로젝트 분석 보고서</h1>

--- a/src/types/projectAnalysis.type.ts
+++ b/src/types/projectAnalysis.type.ts
@@ -48,4 +48,5 @@ export type AdminBatchStatusResponseType = {
     counts: BatchStatusCountsType;
     analyses: AdminBatchAnalysisItemType[];
     portfolioJobId?: number | null; // NONSTOP 포폴 AiJob id(있으면 진행중 페이지가 polling해 PDF 렌더)
+    portfolioRetryable?: boolean; // NONSTOP 전원성공이나 포폴 핸드오프 미완(자동 실패) → 재시도 노출(새로고침에도 유지)
 };

--- a/src/types/projectAnalysis.type.ts
+++ b/src/types/projectAnalysis.type.ts
@@ -47,4 +47,5 @@ export type AdminBatchStatusResponseType = {
     allTerminal: boolean;
     counts: BatchStatusCountsType;
     analyses: AdminBatchAnalysisItemType[];
+    portfolioJobId?: number | null; // NONSTOP 포폴 AiJob id(있으면 진행중 페이지가 polling해 PDF 렌더)
 };


### PR DESCRIPTION
## 요약
프로젝트 분석 NONSTOP 모드 FE — 업로드 모달/진행 화면 + 백엔드 보강에 맞춘 `fileId` 전송 및 재시도 UI.

## 변경
- 분석 시작 시 `pdfUrl`(원시 CDN URL) 대신 **`fileId` 전송** — 서버가 소유권 검증·URL 생성(IDOR/SSRF 차단).
- 진행 화면에 `portfolioRetryable` 시 **'포트폴리오 생성 다시 시도'** 버튼 + 재시도 후 상태 재조회.
- `postStartAnalysis(fileId)` / `retryPortfolioHandoff` / `apiEndpoints.retryPortfolio` 추가.
- (브랜치 포함) NONSTOP 업로드 모달 + 포트폴리오 생성 진행 표시.

## 검증
- `npm run build`(`tsc -b && vite build`) 통과(최신 main rebase 후).
- 4개 수동 모드(UploadPage) 무영향.

## 배포 주의
BE(`StartRequest.fileId`)와 **동시 배포** 필요(계약 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)