### PR TITLE
fix/nonstop-portfolio-pending-polling: 포폴 핸드오프 in-flight 동안 폴링 지속(생성 시작 실패 오표시 수정)

### DIFF
--- a/src/hooks/useAnalysisProgress.ts
+++ b/src/hooks/useAnalysisProgress.ts
@@ -39,6 +39,12 @@ export type UseAnalysisProgressReturnType = {
 const toAnalysisStatus = (raw: string): AnalysisStatusType =>
     raw === 'YET' || raw === 'IN_PROGRESS' || raw === 'DONE' || raw === 'FAILED' ? raw : 'IN_PROGRESS';
 
+// 폴링 종료 신호: 분석 전원 종료 + 포폴 핸드오프 결판(in-flight 아님).
+// allTerminal만으로 멈추면 NONSTOP 핸드오프(FastAPI 호출 ~1-2s) 중에 폴링이 끊겨 portfolioJobId를
+// 못 받고 "생성 시작 실패"로 오표시된다(SSE 불능 시 영구). portfolioPending 동안은 폴링을 이어간다.
+const isSettled = (s: AnalysisBatchStatusType | null | undefined): boolean =>
+    !!s && s.allTerminal && !s.portfolioPending;
+
 /**
  * 본인 배치 진행 상태 관리.
  * - 마운트 시 GET(getUserBatchStatus)으로 시드.
@@ -68,7 +74,7 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
             const data = await getUserBatchStatus(batchId);
             setStatus(data);
             setErrorMessage(null);
-            if (data.allTerminal) clearPoll();
+            if (isSettled(data)) clearPoll();
         } catch {
             setErrorMessage('분석 상태를 불러오지 못했습니다.');
         }
@@ -77,7 +83,7 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
     const ensureSafetyPoll = useCallback(() => {
         if (pollRef.current !== null) return;
         pollRef.current = setInterval(() => {
-            if (statusRef.current?.allTerminal) {
+            if (isSettled(statusRef.current)) {
                 clearPoll();
                 return;
             }
@@ -98,7 +104,7 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
             .then((data) => {
                 if (cancelled) return;
                 setStatus(data);
-                if (!data.allTerminal) ensureSafetyPoll();
+                if (!isSettled(data)) ensureSafetyPoll();
             })
             .catch(() => {
                 if (!cancelled) setErrorMessage('분석 상태를 불러오지 못했습니다.');

--- a/src/pages/Analysis/AnalysisProgressPage.tsx
+++ b/src/pages/Analysis/AnalysisProgressPage.tsx
@@ -242,6 +242,14 @@ export const AnalysisProgressPage = () => {
                             </div>
                         )}
 
+                        {/* NONSTOP 포폴 핸드오프 in-flight(FastAPI 호출 중) — 곧 portfolioJobId가 잡힘 */}
+                        {status.portfolioJobId == null && status.portfolioPending && (
+                            <div className="mt-5 rounded-xl border border-white/[0.08] bg-[#101114]/70 px-4 py-4">
+                                <p className="text-sm font-semibold text-white">포트폴리오 생성 준비 중…</p>
+                                <p className="mt-1 text-sm text-zinc-400">분석 결과로 포트폴리오 생성을 시작하고 있습니다.</p>
+                            </div>
+                        )}
+
                         {/* NONSTOP 포폴 자동 핸드오프 실패 → 수동 재시도(portfolioJobId 없고 retryable일 때만) */}
                         {status.portfolioJobId == null && status.portfolioRetryable && (
                             <div className="mt-5 rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-4">

--- a/src/types/projectAnalysis.type.ts
+++ b/src/types/projectAnalysis.type.ts
@@ -49,4 +49,5 @@ export type AdminBatchStatusResponseType = {
     analyses: AdminBatchAnalysisItemType[];
     portfolioJobId?: number | null; // NONSTOP 포폴 AiJob id(있으면 진행중 페이지가 polling해 PDF 렌더)
     portfolioRetryable?: boolean; // NONSTOP 전원성공이나 포폴 핸드오프 미완(자동 실패) → 재시도 노출(새로고침에도 유지)
+    portfolioPending?: boolean; // 핸드오프 in-flight(FastAPI 호출 중) — 폴링 지속·재시도 미노출(retryable과 상호배타)
 };


### PR DESCRIPTION
## 요약
NONSTOP 분석 완료 직후 포트폴리오 핸드오프(FastAPI 호출) 중에 폴링이 끊겨 `portfolioJobId`를 못 받고 "포트폴리오 생성 시작 실패"로 오표시되던 문제 수정.

## 변경
- `useAnalysisProgress`: 폴링 종료 조건 `allTerminal` → `isSettled = allTerminal && !portfolioPending`. NONSTOP 핸드오프 in-flight 동안 폴링을 이어가 `portfolioJobId`를 picking → SSE가 그 이벤트를 놓쳐도 정확.
- `AnalysisProgressPage`: `portfolioPending` 동안 "포트폴리오 생성 준비 중…" 표시(빈 화면 순간 제거).
- 타입: `AdminBatchStatusResponseType.portfolioPending`.

## 의존
- BE PR(`fix/nonstop-portfolio-retryable-race`)의 `portfolioPending` 필드 필요 → **함께 배포**.

## 검증
- `npm run build`(tsc+vite) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)