### PR TITLE
fix(ai-job): AI 잡 상태 응답 필드명 BE 일치 — /upload 결과 PDF 다운로드 복구

### DIFF
--- a/src/api/AiJob/aiJobApi.ts
+++ b/src/api/AiJob/aiJobApi.ts
@@ -10,7 +10,7 @@ export type AiJobResponseType = {
 export type AiJobStatusResponseType = {
     jobId: number;
     status: AiJobStatus;
-    outputPdfS3Url: string | null;
+    outputPdfUrl: string | null;
     errorMessage: string | null;
 };
 

--- a/src/hooks/useAnalysisProgress.ts
+++ b/src/hooks/useAnalysisProgress.ts
@@ -198,7 +198,7 @@ export function useAnalysisProgress(batchId: string | undefined): UseAnalysisPro
             try {
                 const j = await getAiJobStatus(portfolioJobId);
                 if (cancelled) return;
-                setPortfolioJob({ status: j.status, pdfUrl: j.outputPdfS3Url, errorMessage: j.errorMessage });
+                setPortfolioJob({ status: j.status, pdfUrl: j.outputPdfUrl, errorMessage: j.errorMessage });
                 if (j.status === 'DONE' || j.status === 'ERROR') return; // 종료 → 폴링 중지
             } catch {
                 /* 일시 오류 무시, 다음 폴링에서 재시도 */

--- a/src/pages/Upload/UploadPage.tsx
+++ b/src/pages/Upload/UploadPage.tsx
@@ -123,7 +123,7 @@ export const UploadPage = () => {
       try {
         const res = await getAiJobStatus(jobId);
         patch(index, {
-          job: { jobId: res.jobId, status: res.status, outputUrl: res.outputPdfS3Url, errorMessage: res.errorMessage },
+          job: { jobId: res.jobId, status: res.status, outputUrl: res.outputPdfUrl, errorMessage: res.errorMessage },
         });
         if (res.status === 'PENDING') pollJobStatus(index, jobId);
       } catch {


### PR DESCRIPTION
## 문제
`/upload`(수동 AI 변환)에서 업로드 후 AI 잡이 **DONE**이 돼도 "결과 PDF 다운로드" 버튼이 끝내 뜨지 않음.
(사용자 증상: "업로드 완료만 뜨고 PDF 다운로드는 안뜬다.")

## 원인 — BE↔FE 응답 필드명 불일치
- BE `GET /api/v1/ai/jobs/{jobId}` → `AiDto.JobStatusResponse`는 `@JsonNaming(SnakeCase)`가 **없어** 기본 camelCase로 **`outputPdfUrl`** 직렬화.
  (snake_case는 FastAPI로 *나가는* 요청 DTO에만 적용됨.)
- FE는 응답을 **`outputPdfS3Url`**로 읽어 항상 `undefined` → `slot.job.outputUrl` falsy → 다운로드 `<a>` 미렌더.
- NONSTOP 포폴 진행 훅(`useAnalysisProgress`)도 동일 버그.

## 변경 (FE 3곳, `outputPdfS3Url` → `outputPdfUrl`)
- `src/api/AiJob/aiJobApi.ts` — `AiJobStatusResponseType` 필드
- `src/pages/Upload/UploadPage.tsx` — 폴링 결과 매핑
- `src/hooks/useAnalysisProgress.ts` — NONSTOP 포폴 잡 폴링

내부 상태 키(`job.outputUrl`, `portfolioJob.pdfUrl`)는 FE 자체 명칭이라 그대로 둠. **BE 변경 없음.**

## 검증
- `npx tsc --noEmit` 통과, `npm run build` 통과, `outputPdfS3Url` 잔재 0건.

## 비고
- 이 PR은 "잡이 DONE이면 다운로드가 뜨게" 하는 FE 버그 픽스. 포트폴리오 생성류 잡은 타팀 FastAPI NameError 미수정 시 여전히 ERROR로 뜰 수 있음(별개 이슈, 버그리포트 전달 완료).

🤖 Generated with [Claude Code](https://claude.com/claude-code)