### PR TITLE
fix(ai-job): 자소서→포트폴리오 생성 엔드포인트 경로 수정 (404 → 정상)

### DIFF
--- a/src/api/Http/apiEndpoints.ts
+++ b/src/api/Http/apiEndpoints.ts
@@ -41,7 +41,7 @@ export const API_ENDPOINTS = {
         portfolioFromPdf: '/api/v1/ai/jobs/portfolio/from-pdf',
         coverLetterFromPdf: '/api/v1/ai/jobs/cover-letter/from-pdf',
         coverLetterFromPortfolio: '/api/v1/ai/jobs/cover-letter/from-portfolio',
-        coverLetterToPortfolio: '/api/v1/ai/jobs/cover-letter/to-portfolio',
+        coverLetterToPortfolio: '/api/v1/ai/jobs/portfolio/from-cover-letter',
         status: (jobId: number) => `/api/v1/ai/jobs/${jobId}`,
     },
     projectAnalysis: {


### PR DESCRIPTION
## 문제
`/upload`에서 **자기소개서 슬롯 + "포트폴리오 생성하기"(GENERATE)** 조합에서만 "업로드 실패"가 뜸.
Spring Boot 로그상 S3 업로드는 정상 완료됨.

## 원인 — FE 엔드포인트 경로 오타로 404
- FE `coverLetterToPortfolio` = `/api/v1/ai/jobs/cover-letter/to-portfolio` → BE에 **없는 경로**.
- BE 실제 매핑은 `/api/v1/ai/jobs/portfolio/from-cover-letter` (`AiController.startPortfolioFromCoverLetter`, BE→FastAPI `/portfolio/from-cover-letter`와도 일치).
- 결과: AI 잡 시작 POST가 404로 throw → `UploadPage`의 `try`가 S3 성공(`uploadStatus='done'`) 직후 catch에서 `uploadStatus='error'`로 덮음 → 화면만 "업로드 실패".
- 다른 3개 조합(`portfolio/from-pdf`, `cover-letter/from-pdf`, `cover-letter/from-portfolio`)은 BE와 일치해 정상.

## 변경 (1줄)
- `src/api/Http/apiEndpoints.ts` — `coverLetterToPortfolio` 경로를 `portfolio/from-cover-letter`로 교정.
- 요청 DTO(`fileId/jobPosition/career`)는 BE `CoverLetterJobRequest`와 그대로 일치 → 추가 변경 없음.

## 검증
- `npx tsc --noEmit` 통과, `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)