### PR TITLE
fix(roadmap): coverage_level 리네임 누락으로 깨진 Cloudflare 빌드 복구

### DIFF
--- a/src/components/Profile/RoadmapTabSection.tsx
+++ b/src/components/Profile/RoadmapTabSection.tsx
@@ -119,7 +119,7 @@ export function RoadmapTabSection({ serviceKey }: { serviceKey?: string }) {
         <div className="flex flex-wrap items-center gap-3 text-sm text-zinc-400">
           <span className="font-semibold text-white">{data.llm_assessment.overall_level}</span>
           <span className="h-3.5 w-px bg-white/10" />
-          <span>{roleData.level} · {roleData.topic_coverage} 토픽 커버</span>
+          <span>{roleData.coverage_level} · {roleData.topic_coverage} 토픽 커버</span>
         </div>
       </div>
 


### PR DESCRIPTION
## 문제
Cloudflare 빌드가 `tsc -b`에서 실패:
```
src/components/Profile/RoadmapTabSection.tsx(122,27): error TS2339: Property 'level' does not exist on type 'PerRoleData'.
```

## 원인
`840c36b`("로드맵 페이지 소폭 수정")가 `PerRoleData.level` → **`coverage_level`**로 타입(`roadmap.type.ts`)과 목(`__mock__roadmapApi.ts`)을 리네임했으나, 소비처 `RoadmapTabSection.tsx:122`(`roleData.level`)를 함께 수정하지 않아 누락됨. 해당 파일은 그 커밋의 변경 대상이 아니었음.
- 전체 검색 결과 누락된 소비처는 이 한 곳뿐.

## 변경 (1줄)
- `RoadmapTabSection.tsx:122` `roleData.level` → `roleData.coverage_level`

## 검증
- Cloudflare와 동일하게 `npm run build`(= `tsc -b && vite build`) 로컬 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)