### PR TITLE
fix(roadmap): FE를 BE relay 경로로 정합

### DIFF
--- a/src/api/AiJob/aiJobApi.ts
+++ b/src/api/AiJob/aiJobApi.ts
@@ -11,6 +11,7 @@ export type AiJobStatusResponseType = {
     jobId: number;
     status: AiJobStatus;
     outputPdfUrl: string | null;
+    resultJson: string | null; // 로드맵 등 JSON 결과(DONE일 때 non-null)
     errorMessage: string | null;
 };
 

--- a/src/api/Http/apiEndpoints.ts
+++ b/src/api/Http/apiEndpoints.ts
@@ -43,6 +43,7 @@ export const API_ENDPOINTS = {
         coverLetterFromPortfolio: '/api/v1/ai/jobs/cover-letter/from-portfolio',
         coverLetterToPortfolio: '/api/v1/ai/jobs/portfolio/from-cover-letter',
         status: (jobId: number) => `/api/v1/ai/jobs/${jobId}`,
+        roadmapAssess: '/api/v1/ai/jobs/roadmap/assess', // 로드맵 평가 시작(BE relay → FastAPI)
     },
     projectAnalysis: {
         precheck: '/api/v1/project-analysis/precheck', // POST(시작) / GET(상태 목록)
@@ -62,10 +63,6 @@ export const API_ENDPOINTS = {
     adminUsers: {
         signupsDaily: '/api/v1/admin/users/signups-daily',
         list: '/api/v1/admin/users',
-    },
-    roadmap: {
-        assess: '/api/v1/roadmap/assess',
-        stream: (jobId: string) => `/api/v1/roadmap/jobs/${jobId}/stream`,
     },
 } as const;
 

--- a/src/api/RoadMap/roadmapAssessApi.ts
+++ b/src/api/RoadMap/roadmapAssessApi.ts
@@ -1,53 +1,77 @@
 import { axiosInstance } from '@/api/Http/axiosInstance';
 import { API_ENDPOINTS } from '@/api/Http/apiEndpoints';
+import { getAiJobStatus } from '@/api/AiJob/aiJobApi';
 import type { RoadmapAssessment } from '@/types/roadmap.type';
 
 export type RoadmapAssessJobResponse = {
-    job_id: string;
+    jobId: number;
 };
 
-export const postRoadmapAssess = async (analysisData: unknown): Promise<RoadmapAssessJobResponse> => {
+/**
+ * 로드맵 평가 시작 (BE relay). 완료된 분석 ID들을 BE에 넘기면 BE가 presigned URL로
+ * 변환해 FastAPI에 전달한다. 결과는 잡 폴링(getAiJobStatus의 resultJson)으로 수신.
+ */
+export const postRoadmapAssess = async (
+    analysisIds: string[],
+    merge: boolean,
+): Promise<RoadmapAssessJobResponse> => {
     const { data } = await axiosInstance.post<RoadmapAssessJobResponse>(
-        API_ENDPOINTS.roadmap.assess,
-        analysisData,
+        API_ENDPOINTS.aiJobs.roadmapAssess,
+        { analysisIds, merge },
     );
     return data;
 };
 
-export function streamRoadmapJob(
-    jobId: string,
+const POLL_INTERVAL_MS = 4000;
+
+/** FastAPI 결과는 merge=false면 배열, merge=true면 단건. FE는 단건을 렌더하므로 배열이면 첫 항목. */
+function parseAssessment(resultJson: string): RoadmapAssessment {
+    const parsed = JSON.parse(resultJson) as RoadmapAssessment | RoadmapAssessment[];
+    return Array.isArray(parsed) ? parsed[0] : parsed;
+}
+
+/**
+ * 로드맵 잡 결과를 폴링한다(BE GET /ai/jobs/{jobId}). DONE이면 resultJson 파싱→onResult,
+ * ERROR면 onError. 반환된 함수를 호출하면 폴링을 중단한다.
+ */
+export function pollRoadmapResult(
+    jobId: number,
     onResult: (result: RoadmapAssessment) => void,
     onError: (msg: string) => void,
 ): () => void {
-    const base = import.meta.env.VITE_API_BASE_URL || '';
-    const url = `${base}${API_ENDPOINTS.roadmap.stream(jobId)}`;
-    let es: EventSource;
-    try {
-        es = new EventSource(url, { withCredentials: true });
-    } catch {
-        onError('SSE 연결을 시작할 수 없습니다.');
-        return () => {};
-    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
-    const handleData = (raw: string) => {
+    const tick = async () => {
+        if (cancelled) return;
         try {
-            const parsed = JSON.parse(raw) as RoadmapAssessment;
-            onResult(parsed);
-            es.close();
+            const res = await getAiJobStatus(jobId);
+            if (cancelled) return;
+            if (res.status === 'DONE') {
+                if (!res.resultJson) {
+                    onError('완료됐지만 결과가 비어 있습니다.');
+                    return;
+                }
+                try {
+                    onResult(parseAssessment(res.resultJson));
+                } catch {
+                    onError('결과 파싱 오류');
+                }
+                return;
+            }
+            if (res.status === 'ERROR') {
+                onError(res.errorMessage ?? '로드맵 평가 중 오류가 발생했습니다.');
+                return;
+            }
+            timer = setTimeout(() => void tick(), POLL_INTERVAL_MS); // PENDING → 계속 폴링
         } catch {
-            onError('결과 파싱 오류');
-            es.close();
+            timer = setTimeout(() => void tick(), POLL_INTERVAL_MS); // 일시 오류 무시, 재시도
         }
     };
 
-    es.addEventListener('message', (ev) => handleData((ev as MessageEvent).data));
-    es.addEventListener('result', (ev) => handleData((ev as MessageEvent).data));
-    es.addEventListener('done', (ev) => handleData((ev as MessageEvent).data));
-
-    es.onerror = () => {
-        onError('SSE 연결 오류가 발생했습니다.');
-        es.close();
+    timer = setTimeout(() => void tick(), POLL_INTERVAL_MS);
+    return () => {
+        cancelled = true;
+        if (timer) clearTimeout(timer);
     };
-
-    return () => es.close();
 }

--- a/src/components/AdminPortal/AdminRoadmapTestView.tsx
+++ b/src/components/AdminPortal/AdminRoadmapTestView.tsx
@@ -1,48 +1,54 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
-import { postRoadmapAssess, streamRoadmapJob } from '@/api/RoadMap/roadmapAssessApi';
+import { postRoadmapAssess, pollRoadmapResult } from '@/api/RoadMap/roadmapAssessApi';
 import type { RoadmapAssessment } from '@/types/roadmap.type';
 
 const RoadmapTabSection = lazy(() => import('@/components/Profile/RoadmapTabSection'));
 
-const CDN_JSON_URL = 'https://cdn.passfolio.dev/analyses/hooby/deokive-be-youcu-1/final.json';
-
-type Phase = 'idle' | 'posting' | 'streaming' | 'done' | 'error';
+type Phase = 'idle' | 'posting' | 'polling' | 'done' | 'error';
 
 const PHASE_LABEL: Record<Phase, string> = {
     idle: '',
     posting: '서버에 분석 요청 중...',
-    streaming: 'Job 결과 수신 중...',
+    polling: 'Job 결과 대기 중...',
     done: '',
     error: '',
 };
 
 export function AdminRoadmapTestView() {
+    const [analysisIdsInput, setAnalysisIdsInput] = useState('');
+    const [merge, setMerge] = useState(true);
     const [phase, setPhase] = useState<Phase>('idle');
-    const [jobId, setJobId] = useState<string | null>(null);
+    const [jobId, setJobId] = useState<number | null>(null);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
     const [result, setResult] = useState<RoadmapAssessment | null>(null);
-    const esCleanupRef = useRef<(() => void) | null>(null);
+    const pollCleanupRef = useRef<(() => void) | null>(null);
 
     useEffect(() => {
         return () => {
-            esCleanupRef.current?.();
+            pollCleanupRef.current?.();
         };
     }, []);
 
     const handleStart = async () => {
-        esCleanupRef.current?.();
+        pollCleanupRef.current?.();
+        const analysisIds = analysisIdsInput.split(',').map((s) => s.trim()).filter(Boolean);
+        if (analysisIds.length === 0) {
+            setErrorMsg('분석 ID를 1개 이상 입력하세요(콤마 구분).');
+            setPhase('error');
+            return;
+        }
         setPhase('posting');
         setErrorMsg(null);
         setResult(null);
         setJobId(null);
 
         try {
-            const { job_id } = await postRoadmapAssess({ analysis_url: CDN_JSON_URL });
-            setJobId(job_id);
+            const { jobId: id } = await postRoadmapAssess(analysisIds, merge);
+            setJobId(id);
 
-            setPhase('streaming');
-            const cleanup = streamRoadmapJob(
-                job_id,
+            setPhase('polling');
+            const cleanup = pollRoadmapResult(
+                id,
                 (data) => {
                     setResult(data);
                     setPhase('done');
@@ -52,19 +58,35 @@ export function AdminRoadmapTestView() {
                     setPhase('error');
                 },
             );
-            esCleanupRef.current = cleanup;
+            pollCleanupRef.current = cleanup;
         } catch (e) {
             setErrorMsg(e instanceof Error ? e.message : '알 수 없는 오류');
             setPhase('error');
         }
     };
 
-    const isRunning = phase === 'posting' || phase === 'streaming';
+    const isRunning = phase === 'posting' || phase === 'polling';
 
     return (
         <div className="flex flex-col gap-6">
             {/* 컨트롤 영역 */}
             <div className="flex flex-col gap-3 rounded-xl border border-white/8 bg-[#16171a] p-4">
+                <div className="flex flex-col gap-1.5">
+                    <label className="text-xs text-zinc-400">완료된 분석 ID (콤마 구분)</label>
+                    <input
+                        type="text"
+                        value={analysisIdsInput}
+                        onChange={(e) => setAnalysisIdsInput(e.target.value)}
+                        disabled={isRunning}
+                        placeholder="예: 2f1ac9fd-..., 957e7ab9-..."
+                        className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none placeholder:text-zinc-600 focus:border-white/20 disabled:opacity-50"
+                    />
+                    <label className="flex items-center gap-2 text-xs text-zinc-400">
+                        <input type="checkbox" checked={merge} onChange={(e) => setMerge(e.target.checked)} disabled={isRunning} className="accent-white" />
+                        merge (여러 분석을 하나로 합쳐 평가)
+                    </label>
+                </div>
+
                 <div className="flex flex-wrap items-center gap-3">
                     <button
                         type="button"
@@ -91,10 +113,6 @@ export function AdminRoadmapTestView() {
                 </div>
 
                 <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-zinc-500">
-                    <span>
-                        <span className="text-zinc-400">소스: </span>
-                        <code className="text-zinc-300">{CDN_JSON_URL}</code>
-                    </span>
                     {jobId && (
                         <span>
                             <span className="text-zinc-400">Job ID: </span>


### PR DESCRIPTION
## 배경
로드맵 심층분석 결과, FE가 **FastAPI 스타일 경로**(`/api/v1/roadmap/assess`, `/api/v1/roadmap/jobs/{id}/stream`)를 단일 `{analysis_url}`로 호출 → BE 경로/바디와 불일치로 미연동. 통합을 **BE relay**로 정합하기로 함(BE PR #34와 짝).

## 변경
- **시작**: `POST /api/v1/ai/jobs/roadmap/assess` body `{analysisIds, merge}` → `{jobId}` (BE 경로/바디로 전환).
- **결과 수신**: 기존 AI 잡과 동일하게 `getAiJobStatus(jobId)` **폴링** → `resultJson` 파싱(merge=false면 배열 → 첫 항목). 옛 SSE `streamRoadmapJob` 제거.
- `aiJobApi`: `AiJobStatusResponseType`에 `resultJson` 추가(BE `JobStatusResponse` 일치).
- `apiEndpoints`: `aiJobs.roadmapAssess` 추가, 옛 FastAPI 스타일 `roadmap` 블록 제거.
- `AdminRoadmapTestView`: 하드코딩 CDN URL → **분석 ID 입력(콤마 구분) + merge 체크** + 폴링.
- 렌더(`RoadmapTabSection`)는 result JSON ↔ `RoadmapAssessment` 호환이라 미변경.

## 검증
- `npx tsc --noEmit` 통과, `npm run build` 통과, 잔재 참조 0.

## 의존
- BE PR #34(경로 404 픽스 + 공용 웹훅 방어)와 함께. + FastAPI(타팀)가 로드맵 완료를 `/api/v1/ai/roadmap/complete`로 result 포함해 보내야 결과가 흐름(별도 협의).

🤖 Generated with [Claude Code](https://claude.com/claude-code)