### PR TITLE
perf(deck): 콜드 스타트 최적화 + 프리로드 게이트, 커버·Performance 콘텐츠 수정

### DIFF
--- a/src/pages/Documentation/DeckPage.tsx
+++ b/src/pages/Documentation/DeckPage.tsx
@@ -4,31 +4,18 @@ import Reveal from 'reveal.js';
 import 'reveal.js/reveal.css';
 import './deck/deck.css';
 import { DECK_SLIDES, type SlideProps } from './deck/slides';
+import { DeckLoadingOverlay } from './deck/DeckLoadingOverlay';
+import { ensureDeckFontStylesheet } from './deck/deckFonts';
+import { useDeckPreload } from './deck/useDeckPreload';
 
 // StrictMode(mount→unmount→mount)에서 reveal 인스턴스의 비동기 initialize/destroy가
 // 서로 겹치면 나중 인스턴스의 레이아웃을 이전 인스턴스의 destroy가 걷어낸다.
 // 모듈 레벨 프라미스 체인으로 생성→init→파기 순서를 직렬화한다.
 let revealLifecycle: Promise<void> = Promise.resolve();
 
-const DECK_FONT_LINK_ID = 'pf-deck-fonts';
-const DECK_FONT_HREF =
-    'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600&display=swap';
-
-/** 슬라이드 전용 폰트(Poppins/Noto Sans KR/JetBrains Mono)를 덱 라우트에서만 로드 */
-function useDeckFonts() {
-    useEffect(() => {
-        if (document.getElementById(DECK_FONT_LINK_ID)) return;
-        const link = document.createElement('link');
-        link.id = DECK_FONT_LINK_ID;
-        link.rel = 'stylesheet';
-        link.href = DECK_FONT_HREF;
-        document.head.appendChild(link);
-        // unmount 시 제거하지 않는다 — 재방문 대비 캐시 유지, 미사용 시 무해
-    }, []);
-}
-
 export default function DeckPage() {
     const deckRootRef = useRef<HTMLDivElement>(null);
+    const deckInstanceRef = useRef<InstanceType<typeof Reveal> | null>(null);
     // -1: 아직 어떤 슬라이드도 active가 아님 → 전 슬라이드 is-loading 상태로 첫 페인트
     const [activeIndex, setActiveIndex] = useState(-1);
     // 오버뷰 모드에선 전 슬라이드 썸네일이 보여야 하므로 일괄 활성화
@@ -39,14 +26,34 @@ export default function DeckPage() {
         [],
     );
 
-    useDeckFonts();
+    // 프리로더도 폰트를 주입하지만, 게이트가 꺼지는 print 모드를 위해 무조건 1회 보장
+    useEffect(() => {
+        void ensureDeckFontStylesheet();
+    }, []);
+
+    // ---- 진입 게이트: 전 슬라이드 이미지·폰트가 로드될 때까지 오버레이로 막고,
+    //      그 뒤에서 reveal을 먼저 init해 착지 슬라이드의 레이어를 미리 래스터화한다.
+    const gateEnabled = !isPrintView;
+    const { ready, loaded, total } = useDeckPreload(gateEnabled);
+    const [revealInitialized, setRevealInitialized] = useState(false);
+    const [gateOpen, setGateOpen] = useState(!gateEnabled);
+    const [overlayGone, setOverlayGone] = useState(!gateEnabled);
+    const gateOpenRef = useRef(!gateEnabled);
+    // 해시(#/n) 딥링크 포함, 게이트 오픈 시 엔트런스를 재생할 착지 슬라이드
+    const landedIndexRef = useRef<number | null>(null);
 
     useEffect(() => {
         const rootEl = deckRootRef.current!;
         let deck: InstanceType<typeof Reveal> | null = null;
         let cancelled = false;
         const onSlideChanged = (event: Event) => {
-            setActiveIndex((event as unknown as { indexh: number }).indexh);
+            const indexh = (event as unknown as { indexh: number }).indexh;
+            // 게이트 오픈 전 내비게이션은 착지 인덱스만 갱신 — 엔트런스가 몰래 소모되지 않게
+            if (!gateOpenRef.current) {
+                landedIndexRef.current = indexh;
+                return;
+            }
+            setActiveIndex(indexh);
         };
         const onOverviewShown = () => setIsOverview(true);
         const onOverviewHidden = () => setIsOverview(false);
@@ -63,7 +70,8 @@ export default function DeckPage() {
                 controls: true,
                 progress: true,
                 overview: true,
-                keyboard: true,
+                // 게이트 오픈 전 키보드 내비/오버뷰 진입 차단 (오픈 시 configure로 복원)
+                keyboard: !gateEnabled,
                 touch: true,
                 // 뷰포트 폭 435px 미만에서 자동 Scroll View 전환 방지 —
                 // 모바일에서도 데스크탑과 동일한 scale-to-fit 고정 덱 유지
@@ -71,7 +79,9 @@ export default function DeckPage() {
             });
             await deck.initialize();
             if (cancelled) return; // 파기는 cleanup이 체인 뒤에서 수행
-            setActiveIndex(deck.getIndices().h);
+            deckInstanceRef.current = deck;
+            landedIndexRef.current = deck.getIndices().h;
+            setRevealInitialized(true);
             deck.on('slidechanged', onSlideChanged);
             deck.on('overviewshown', onOverviewShown);
             deck.on('overviewhidden', onOverviewHidden);
@@ -81,6 +91,7 @@ export default function DeckPage() {
             cancelled = true;
             revealLifecycle = revealLifecycle.then(() => {
                 if (!deck) return;
+                deckInstanceRef.current = null;
                 deck.off('slidechanged', onSlideChanged);
                 deck.off('overviewshown', onOverviewShown);
                 deck.off('overviewhidden', onOverviewHidden);
@@ -92,7 +103,41 @@ export default function DeckPage() {
                 deck = null;
             });
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // 게이트 오픈: 프리로드 + reveal init 완료 → 한 프레임 뒤(is-loading 상태가 페인트된 후)
+    // 오버레이 페이드와 함께 착지 슬라이드의 엔트런스를 재생한다.
+    useEffect(() => {
+        if (!ready || !revealInitialized || gateOpen) return;
+        const raf = requestAnimationFrame(() => {
+            gateOpenRef.current = true;
+            setGateOpen(true);
+            setActiveIndex(landedIndexRef.current ?? 0);
+            deckInstanceRef.current?.configure({ keyboard: true });
+        });
+        return () => cancelAnimationFrame(raf);
+    }, [ready, revealInitialized, gateOpen]);
+
+    // 오버레이는 페이드(0.35s)가 끝난 뒤 언마운트
+    useEffect(() => {
+        if (!gateOpen || overlayGone) return;
+        const timer = setTimeout(() => setOverlayGone(true), 400);
+        return () => clearTimeout(timer);
+    }, [gateOpen, overlayGone]);
+
+    // 근접 슬라이드(현재 ±1)에만 pf-near를 붙여 엔트런스 요소의 컴포지터 레이어를
+    // 사전 승격한다. reveal이 section 클래스(present/past/future)를 직접 관리하므로
+    // React className이 아닌 classList로만 조작한다.
+    useEffect(() => {
+        const rootEl = deckRootRef.current;
+        if (!rootEl || isPrintView) return;
+        const center = activeIndex >= 0 ? activeIndex : (landedIndexRef.current ?? 0);
+        const sections = rootEl.querySelectorAll<HTMLElement>('.slides > section');
+        sections.forEach((el, i) => {
+            el.classList.toggle('pf-near', Math.abs(i - center) <= 1);
+        });
+    }, [activeIndex, revealInitialized, isPrintView]);
 
     return (
         <div className={`pf-deck${isPrintView ? ' pf-print' : ''}`}>
@@ -112,6 +157,9 @@ export default function DeckPage() {
                     ))}
                 </div>
             </div>
+            {gateEnabled && !overlayGone && (
+                <DeckLoadingOverlay loaded={loaded} total={total} dismissed={gateOpen} />
+            )}
         </div>
     );
 }

--- a/src/pages/Documentation/DocsPage.tsx
+++ b/src/pages/Documentation/DocsPage.tsx
@@ -1,9 +1,25 @@
+import { useEffect } from 'react';
 import { LanderFooter } from '@/components/Lander/LanderFooter';
 import { ContentCard } from '@/components/Article/ArticleCard';
 import { DOCUMENTATION_LIST } from '@/data/documentation';
+import { warmDeck } from './deck/deckWarmup';
 import '@/pages/Lander/landerPage.css';
 
+const DECK_DOC_ID = 'passfolio-deck';
+
 export function DocsPage() {
+    // 유휴 시간에 덱 JS 청크(reveal.js + 슬라이드)를 미리 당겨 라우트 진입 지연 제거.
+    // 이미지·폰트까지 당기는 warmDeck은 카드에 인텐트(호버/터치)가 있을 때만.
+    useEffect(() => {
+        // Safari 등 requestIdleCallback 미지원 브라우저는 setTimeout 폴백
+        if (typeof window.requestIdleCallback === 'function') {
+            const id = window.requestIdleCallback(() => void import('./DeckPage'));
+            return () => window.cancelIdleCallback(id);
+        }
+        const id = window.setTimeout(() => void import('./DeckPage'), 1500);
+        return () => window.clearTimeout(id);
+    }, []);
+
     return (
         <div className="flex min-h-screen flex-col bg-[#0d0d0f] text-white">
             <main className="relative z-[1] mx-auto w-full max-w-[1080px] flex-1 px-4 pb-20 pt-24 md:px-6 md:pt-28">
@@ -20,15 +36,27 @@ export function DocsPage() {
                 </header>
 
                 <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-                    {DOCUMENTATION_LIST.map((doc) => (
-                        <ContentCard
-                            key={doc.id}
-                            to={doc.href}
-                            title={doc.title}
-                            thumbnail={doc.thumbnail}
-                            createdAt={doc.createdAt}
-                        />
-                    ))}
+                    {DOCUMENTATION_LIST.map((doc) =>
+                        doc.id === DECK_DOC_ID ? (
+                            // grid: 셀 높이를 카드에 그대로 전달 (다른 카드와 동일 높이 유지)
+                            <div key={doc.id} className="grid" onPointerEnter={warmDeck} onPointerDown={warmDeck}>
+                                <ContentCard
+                                    to={doc.href}
+                                    title={doc.title}
+                                    thumbnail={doc.thumbnail}
+                                    createdAt={doc.createdAt}
+                                />
+                            </div>
+                        ) : (
+                            <ContentCard
+                                key={doc.id}
+                                to={doc.href}
+                                title={doc.title}
+                                thumbnail={doc.thumbnail}
+                                createdAt={doc.createdAt}
+                            />
+                        ),
+                    )}
                 </div>
             </main>
 

--- a/src/pages/Documentation/deck/DeckLoadingOverlay.tsx
+++ b/src/pages/Documentation/deck/DeckLoadingOverlay.tsx
@@ -1,0 +1,29 @@
+import './deckLoadingOverlay.css';
+
+type DeckLoadingOverlayProps = {
+    loaded: number;
+    total: number;
+    /** true가 되면 페이드아웃 시작 — 언마운트는 부모가 페이드 후 수행 */
+    dismissed: boolean;
+};
+
+/** 덱 진입 게이트 오버레이 — 덱 폰트 로드 전이므로 시스템 폰트로만 표기한다 */
+export function DeckLoadingOverlay({ loaded, total, dismissed }: DeckLoadingOverlayProps) {
+    const ratio = total > 0 ? Math.min(loaded / total, 1) : 0;
+    return (
+        <div
+            className={`pf-deck-loading${dismissed ? ' is-dismissed' : ''}`}
+            role="status"
+            aria-busy={!dismissed}
+            aria-label="발표 자료 로드 중"
+        >
+            <p className="label">Loading Presentation</p>
+            <div className="track">
+                <div className="fill" style={{ transform: `scaleX(${ratio})` }} />
+            </div>
+            <p className="count">
+                {Math.min(loaded, total)} / {total}
+            </p>
+        </div>
+    );
+}

--- a/src/pages/Documentation/deck/deck.css
+++ b/src/pages/Documentation/deck/deck.css
@@ -94,6 +94,28 @@ body.reveal-viewport {
 }
 
 /* ============================================================
+   첫 재생 컴포지터 워밍 — will-change로 레이어를 트랜지션 발화 전에
+   미리 생성한다. 17장 전체 승격은 GPU 메모리 낭비이므로,
+   근접 슬라이드(pf-near: 현재 ±1, DeckPage가 부여)로만 한정한다.
+   ============================================================ */
+/* 각 슬라이드 is-loading 엔트런스 트랜지션의 대상 클래스 합집합 */
+.pf-deck section.pf-near
+    :is(
+        .corner, .eyebrow, .headline, .title, .lead, .row,
+        .thinker, .sub, .survey, .subtitle, .members-head, .member,
+        .logo-mark, .wordmark, .col, .arrow, .card, .meta,
+        .pillar, .takeaway, .photo-wrap, .panel-label, .bitem,
+        .conclusion, .qa, .lockup, .etym, .synth, .feat-strip, .sys
+    ) {
+    will-change: opacity, transform, filter;
+}
+/* 무한 keyframe 글로우(정적 blur 위에서 transform/opacity만 애니메이션)는 상시 승격 */
+.pf-deck .sl-cover .hero-glow,
+.pf-deck .sl-qna .glow {
+    will-change: transform, opacity;
+}
+
+/* ============================================================
    Print (?print-pdf) — slidechanged가 없으므로 모든 슬라이드를
    isActive로 강제하고, 전환/애니메이션을 죽여 최종 상태로 고정한다.
    ============================================================ */

--- a/src/pages/Documentation/deck/deck.css
+++ b/src/pages/Documentation/deck/deck.css
@@ -105,7 +105,8 @@ body.reveal-viewport {
         .thinker, .sub, .survey, .subtitle, .members-head, .member,
         .logo-mark, .wordmark, .col, .arrow, .card, .meta,
         .pillar, .takeaway, .photo-wrap, .panel-label, .bitem,
-        .conclusion, .qa, .lockup, .etym, .synth, .feat-strip, .sys
+        .conclusion, .qa, .lockup, .etym, .synth, .feat-strip, .sys,
+        .credits, .note
     ) {
     will-change: opacity, transform, filter;
 }

--- a/src/pages/Documentation/deck/deckAssets.ts
+++ b/src/pages/Documentation/deck/deckAssets.ts
@@ -1,0 +1,20 @@
+// 덱 안에서 '@/assets/deck/*'를 import하는 유일한 모듈 — 슬라이드는 반드시
+// 이 매니페스트를 거쳐 에셋을 참조한다. 프리로더(DECK_IMAGE_URLS)가
+// 전 슬라이드의 에셋을 빠짐없이 커버함을 구조적으로 보장하기 위함.
+import analysisWorkflowSrc from '@/assets/deck/analysis-workflow-v3.webp';
+import architectureSrc from '@/assets/deck/architecture.webp';
+import crumpledWoodSrc from '@/assets/deck/crumpled-wood.webp';
+import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import portfolioWorkflowSrc from '@/assets/deck/portfolio-workflow-v2.webp';
+import thinkerSrc from '@/assets/deck/thinker.webp';
+
+export const DECK_ASSETS = {
+    analysisWorkflowSrc,
+    architectureSrc,
+    crumpledWoodSrc,
+    logoSrc,
+    portfolioWorkflowSrc,
+    thinkerSrc,
+} as const;
+
+export const DECK_IMAGE_URLS: readonly string[] = Object.values(DECK_ASSETS);

--- a/src/pages/Documentation/deck/deckFonts.ts
+++ b/src/pages/Documentation/deck/deckFonts.ts
@@ -1,0 +1,42 @@
+const DECK_FONT_LINK_ID = 'pf-deck-fonts';
+
+// Poppins 300: serviceIntroSlide의 .plus/.eq가 font-weight 300을 사용 (원본 덱 의도)
+const DECK_FONT_HREF =
+    'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600&display=swap';
+
+let stylesheetPromise: Promise<void> | null = null;
+
+/** 덱 폰트 stylesheet 주입 (idempotent). 실패 시에도 resolve — 프리로드 게이트를 잠그지 않는다. */
+export function ensureDeckFontStylesheet(): Promise<void> {
+    if (stylesheetPromise) return stylesheetPromise;
+    stylesheetPromise = new Promise((resolve) => {
+        if (document.getElementById(DECK_FONT_LINK_ID)) {
+            resolve();
+            return;
+        }
+        const link = document.createElement('link');
+        link.id = DECK_FONT_LINK_ID;
+        link.rel = 'stylesheet';
+        link.href = DECK_FONT_HREF;
+        link.onload = () => resolve();
+        link.onerror = () => resolve();
+        document.head.appendChild(link);
+        // unmount 시 제거하지 않는다 — 재방문 대비 캐시 유지, 미사용 시 무해
+    });
+    return stylesheetPromise;
+}
+
+// Noto Sans KR은 unicode-range 서브셋 분할이라 한글 샘플이 있어야 실제 서브셋이 다운로드된다
+const KR_SAMPLE = '패스폴리오 발표 자료';
+const LATIN_SAMPLE = 'Passfolio 0123456789';
+
+/** document.fonts.load()에 넘길 (폰트 스펙, 샘플 텍스트) 목록 — DECK_FONT_HREF 선언과 1:1 */
+export const DECK_FONT_SETS: ReadonlyArray<readonly [spec: string, sample: string]> = [
+    ...([300, 400, 500, 600, 700, 800] as const).map(
+        (w) => [`${w} 1rem Poppins`, LATIN_SAMPLE] as const,
+    ),
+    ...([400, 500, 600, 700, 800] as const).map(
+        (w) => [`${w} 1rem "Noto Sans KR"`, KR_SAMPLE] as const,
+    ),
+    ...([500, 600] as const).map((w) => [`${w} 1rem "JetBrains Mono"`, LATIN_SAMPLE] as const),
+];

--- a/src/pages/Documentation/deck/deckLoadingOverlay.css
+++ b/src/pages/Documentation/deck/deckLoadingOverlay.css
@@ -1,0 +1,58 @@
+/* 덱 진입 게이트 오버레이 — 덱 톤(#131418), .pf-deck-exit(z-50)·reveal UI 위를 덮는다 */
+.pf-deck-loading {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    background: #131418;
+    transition: opacity 0.35s ease;
+}
+.pf-deck-loading.is-dismissed {
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* 슬라이드 .corner 키커 톤 — 단, 덱 폰트 로드 전이므로 시스템 폰트 스택 */
+.pf-deck-loading .label {
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.34em;
+    text-transform: uppercase;
+    color: #71717a;
+    /* letter-spacing이 마지막 글자 뒤에도 붙어 시각 중심이 좌측으로 쏠리는 것 보정 */
+    margin-right: -0.34em;
+}
+
+.pf-deck-loading .track {
+    width: min(280px, 60vw);
+    height: 1px;
+    background: rgba(255, 255, 255, 0.08);
+}
+.pf-deck-loading .fill {
+    width: 100%;
+    height: 100%;
+    background: #ffffff;
+    transform-origin: left center;
+    transform: scaleX(0);
+    transition: transform 0.25s ease;
+}
+
+.pf-deck-loading .count {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: #a1a1aa;
+    font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pf-deck-loading,
+    .pf-deck-loading .fill {
+        transition: none !important;
+    }
+}

--- a/src/pages/Documentation/deck/deckWarmup.ts
+++ b/src/pages/Documentation/deck/deckWarmup.ts
@@ -1,0 +1,18 @@
+import { DECK_IMAGE_URLS } from './deckAssets';
+import { ensureDeckFontStylesheet } from './deckFonts';
+
+let warmed = false;
+
+/**
+ * DocsPage에서 덱 진입 인텐트(호버/터치) 시 사전 워밍 — JS 청크 + 폰트 stylesheet +
+ * 이미지 fetch. 디코드는 진입 게이트(useDeckPreload)가 수행하므로 여기선 fetch만.
+ */
+export function warmDeck(): void {
+    if (warmed) return;
+    warmed = true;
+    void import('../DeckPage');
+    void ensureDeckFontStylesheet();
+    for (const url of DECK_IMAGE_URLS) {
+        new Image().src = url;
+    }
+}

--- a/src/pages/Documentation/deck/slides/AnalysisWorkflowSlide.tsx
+++ b/src/pages/Documentation/deck/slides/AnalysisWorkflowSlide.tsx
@@ -1,5 +1,7 @@
-import workflowSrc from '@/assets/deck/analysis-workflow-v3.webp';
+import { DECK_ASSETS } from '../deckAssets';
 import './analysisWorkflowSlide.css';
+
+const workflowSrc = DECK_ASSETS.analysisWorkflowSrc;
 
 export function AnalysisWorkflowSlide() {
     return (
@@ -15,7 +17,7 @@ export function AnalysisWorkflowSlide() {
             </div>
 
             <div className="diagram">
-                <img src={workflowSrc} alt="Passfolio project analysis workflow diagram" loading="lazy" />
+                <img src={workflowSrc} alt="Passfolio project analysis workflow diagram" />
             </div>
 
             <div className="flow">

--- a/src/pages/Documentation/deck/slides/ContentsSlide.tsx
+++ b/src/pages/Documentation/deck/slides/ContentsSlide.tsx
@@ -1,6 +1,8 @@
-import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './contentsSlide.css';
+
+const logoSrc = DECK_ASSETS.logoSrc;
 
 const CONTENTS_ROWS = [
     { no: '01', name: 'Overview', tag: '개요' },

--- a/src/pages/Documentation/deck/slides/CoverSlide.tsx
+++ b/src/pages/Documentation/deck/slides/CoverSlide.tsx
@@ -1,6 +1,8 @@
-import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './coverSlide.css';
+
+const logoSrc = DECK_ASSETS.logoSrc;
 
 export function CoverSlide({ isActive }: SlideProps) {
     return (

--- a/src/pages/Documentation/deck/slides/CoverSlide.tsx
+++ b/src/pages/Documentation/deck/slides/CoverSlide.tsx
@@ -25,6 +25,13 @@ export function CoverSlide({ isActive }: SlideProps) {
                     <h1 className="wordmark">Passfolio</h1>
                 </div>
                 <div className="subtitle">Capstone Design Final Presentation</div>
+                <div className="credits">
+                    <span className="crl">PPT</span>
+                    <span className="crn">김태현</span>
+                    <span className="crd">·</span>
+                    <span className="crl">Presenter</span>
+                    <span className="crn">박준우</span>
+                </div>
             </div>
 
             <div className="members">

--- a/src/pages/Documentation/deck/slides/Feedback1Slide.tsx
+++ b/src/pages/Documentation/deck/slides/Feedback1Slide.tsx
@@ -5,12 +5,13 @@ export function Feedback1Slide({ isActive }: SlideProps) {
     return (
         <div className={`pf-slide sl-feedback-1${isActive ? '' : ' is-loading'}`}>
             <div className="corner left">
-                <span className="num">05</span><span className="sep">•</span><span>Feedback</span>
+                <span className="num">05</span><span className="sep">•</span><span>Performance</span>
             </div>
             <div className="corner right"><span className="pg">15</span></div>
 
             <div className="head">
                 <h1 className="headline">개선 단계별 <span className="accent">포트폴리오 결과 비교</span></h1>
+                <p className="note">* 포트폴리오의 특정 개선 영역만 발췌</p>
             </div>
 
             <div className="cols">

--- a/src/pages/Documentation/deck/slides/OverviewSlide.tsx
+++ b/src/pages/Documentation/deck/slides/OverviewSlide.tsx
@@ -1,6 +1,8 @@
-import thinkerSrc from '@/assets/deck/thinker.webp';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './overviewSlide.css';
+
+const thinkerSrc = DECK_ASSETS.thinkerSrc;
 
 export function OverviewSlide({ isActive }: SlideProps) {
     return (
@@ -12,7 +14,7 @@ export function OverviewSlide({ isActive }: SlideProps) {
                 <span className="pg">03</span>
             </div>
 
-            <img className="thinker" src={thinkerSrc} alt="" loading="lazy" />
+            <img className="thinker" src={thinkerSrc} alt="" />
 
             <div className="content">
                 <div className="eyebrow">MARKET PAIN</div>

--- a/src/pages/Documentation/deck/slides/PerformanceSlide.tsx
+++ b/src/pages/Documentation/deck/slides/PerformanceSlide.tsx
@@ -25,7 +25,7 @@ export function PerformanceSlide() {
     return (
         <div className="pf-slide sl-performance">
             <div className="corner left">
-                <span className="num">06</span><span className="sep">•</span><span>Performance</span>
+                <span className="num">05</span><span className="sep">•</span><span>Performance</span>
             </div>
             <div className="corner right"><span className="pg">16</span></div>
 

--- a/src/pages/Documentation/deck/slides/PortfolioWorkflowSlide.tsx
+++ b/src/pages/Documentation/deck/slides/PortfolioWorkflowSlide.tsx
@@ -1,5 +1,7 @@
-import workflowSrc from '@/assets/deck/portfolio-workflow-v2.webp';
+import { DECK_ASSETS } from '../deckAssets';
 import './portfolioWorkflowSlide.css';
+
+const workflowSrc = DECK_ASSETS.portfolioWorkflowSrc;
 
 export function PortfolioWorkflowSlide() {
     return (
@@ -15,7 +17,7 @@ export function PortfolioWorkflowSlide() {
             </div>
 
             <div className="diagram">
-                <img src={workflowSrc} alt="Passfolio portfolio generation workflow diagram" loading="lazy" />
+                <img src={workflowSrc} alt="Passfolio portfolio generation workflow diagram" />
             </div>
 
             <div className="flow">

--- a/src/pages/Documentation/deck/slides/PurposeCSlide.tsx
+++ b/src/pages/Documentation/deck/slides/PurposeCSlide.tsx
@@ -1,6 +1,8 @@
-import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './purposeCSlide.css';
+
+const logoSrc = DECK_ASSETS.logoSrc;
 
 export function PurposeCSlide({ isActive }: SlideProps) {
     return (
@@ -38,7 +40,7 @@ export function PurposeCSlide({ isActive }: SlideProps) {
                 <div className="pillar featured">
                     <span className="idx">02</span>
                     <span className="badge">
-                        <img src={logoSrc} alt="" loading="lazy" />
+                        <img src={logoSrc} alt="" />
                         <span className="bt">Passfolio</span>
                     </span>
                     <div className="ptitle">포트폴리오 평가</div>

--- a/src/pages/Documentation/deck/slides/PurposeDSlide.tsx
+++ b/src/pages/Documentation/deck/slides/PurposeDSlide.tsx
@@ -1,6 +1,8 @@
-import crumpledWoodSrc from '@/assets/deck/crumpled-wood.webp';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './purposeDSlide.css';
+
+const crumpledWoodSrc = DECK_ASSETS.crumpledWoodSrc;
 
 const BAR_ITEMS = [
     { label: '내용 · 성과를 논리적으로 정리하기', val: '57.5%', pct: 100, lead: true },

--- a/src/pages/Documentation/deck/slides/QnASlide.tsx
+++ b/src/pages/Documentation/deck/slides/QnASlide.tsx
@@ -1,6 +1,8 @@
-import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './qnaSlide.css';
+
+const logoSrc = DECK_ASSETS.logoSrc;
 
 export function QnASlide({ isActive }: SlideProps) {
     return (
@@ -8,7 +10,7 @@ export function QnASlide({ isActive }: SlideProps) {
             <div className="glow" />
 
             <div className="corner left">
-                <img className="logo" src={logoSrc} alt="Passfolio" loading="lazy" />
+                <img className="logo" src={logoSrc} alt="Passfolio" />
                 <span>Passfolio</span>
             </div>
             <div className="corner right"><span>Thank You</span></div>

--- a/src/pages/Documentation/deck/slides/ServiceIntroSlide.tsx
+++ b/src/pages/Documentation/deck/slides/ServiceIntroSlide.tsx
@@ -1,6 +1,8 @@
-import logoSrc from '@/assets/deck/passfolio-logo-cropped.svg';
+import { DECK_ASSETS } from '../deckAssets';
 import type { SlideProps } from './index';
 import './serviceIntroSlide.css';
+
+const logoSrc = DECK_ASSETS.logoSrc;
 
 export function ServiceIntroSlide({ isActive }: SlideProps) {
     return (
@@ -15,7 +17,7 @@ export function ServiceIntroSlide({ isActive }: SlideProps) {
             <div className="brand-col">
                 <div className="intro">
                     <div className="lockup">
-                        <img src={logoSrc} alt="" loading="lazy" />
+                        <img src={logoSrc} alt="" />
                         <span className="wm">Passfolio</span>
                     </div>
                 </div>

--- a/src/pages/Documentation/deck/slides/TechnologySlide.tsx
+++ b/src/pages/Documentation/deck/slides/TechnologySlide.tsx
@@ -1,5 +1,7 @@
-import architectureSrc from '@/assets/deck/architecture.webp';
+import { DECK_ASSETS } from '../deckAssets';
 import './technologySlide.css';
+
+const architectureSrc = DECK_ASSETS.architectureSrc;
 
 export function TechnologySlide() {
     return (
@@ -15,7 +17,7 @@ export function TechnologySlide() {
             </div>
 
             <div className="diagram">
-                <img src={architectureSrc} alt="Passfolio infrastructure architecture diagram" loading="lazy" />
+                <img src={architectureSrc} alt="Passfolio infrastructure architecture diagram" />
             </div>
 
             <div className="summary">

--- a/src/pages/Documentation/deck/slides/coverSlide.css
+++ b/src/pages/Documentation/deck/slides/coverSlide.css
@@ -123,6 +123,35 @@
     letter-spacing: 0.04em;
 }
 
+/* ---- 발표 크레딧 (subtitle 아래) ---- */
+.sl-cover .credits {
+    margin-top: 30px;
+    display: flex;
+    align-items: baseline;
+    gap: 18px;
+}
+.sl-cover .credits .crl {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+}
+.sl-cover .credits .crn {
+    font-family: var(--font-kr);
+    font-size: 21px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    letter-spacing: 0.02em;
+    /* crl의 letter-spacing이 마지막 글자 뒤에도 붙어 벌어진 간격 보정 */
+    margin-left: -6px;
+}
+.sl-cover .credits .crd {
+    color: rgba(255, 255, 255, 0.18);
+    font-size: 18px;
+}
+
 /* ---- Members strip ---- */
 .sl-cover .members {
     position: absolute;
@@ -210,7 +239,7 @@
    해제되어 원본과 동일한 스태거 안무가 재생된다.
    ============================================================ */
 .sl-cover .corner.left, .sl-cover .corner.right, .sl-cover .logo-mark, .sl-cover .wordmark,
-.sl-cover .subtitle, .sl-cover .members-head, .sl-cover .member {
+.sl-cover .subtitle, .sl-cover .credits, .sl-cover .members-head, .sl-cover .member {
     transition-property: opacity, transform, filter;
     transition-duration: 1s;
     transition-timing-function: cubic-bezier(0.2, 0.7, 0.2, 1);
@@ -220,7 +249,8 @@
 .sl-cover .logo-mark    { transition-delay: 0.25s; }
 .sl-cover .wordmark     { transition-delay: 0.42s; }
 .sl-cover .subtitle     { transition-delay: 0.70s; }
-.sl-cover .members-head { transition-delay: 0.82s; }
+.sl-cover .credits      { transition-delay: 0.80s; }
+.sl-cover .members-head { transition-delay: 0.90s; }
 .sl-cover .member:nth-child(1) { transition-delay: 0.95s; }
 .sl-cover .member:nth-child(2) { transition-delay: 1.05s; }
 .sl-cover .member:nth-child(3) { transition-delay: 1.15s; }
@@ -229,6 +259,7 @@
 .sl-cover.is-loading .corner.left,
 .sl-cover.is-loading .corner.right,
 .sl-cover.is-loading .subtitle,
+.sl-cover.is-loading .credits,
 .sl-cover.is-loading .members-head,
 .sl-cover.is-loading .member { opacity: 0; transform: translateY(22px); }
 .sl-cover.is-loading .logo-mark { opacity: 0; transform: translateY(26px) scale(0.94); filter: blur(9px); }
@@ -264,10 +295,10 @@
 
 @media (prefers-reduced-motion: reduce) {
     .sl-cover .corner.left, .sl-cover .corner.right, .sl-cover .logo-mark, .sl-cover .wordmark,
-    .sl-cover .subtitle, .sl-cover .members-head, .sl-cover .member { transition: none !important; }
+    .sl-cover .subtitle, .sl-cover .credits, .sl-cover .members-head, .sl-cover .member { transition: none !important; }
     .sl-cover.is-loading .corner.left, .sl-cover.is-loading .corner.right, .sl-cover.is-loading .logo-mark,
-    .sl-cover.is-loading .wordmark, .sl-cover.is-loading .subtitle, .sl-cover.is-loading .members-head,
-    .sl-cover.is-loading .member {
+    .sl-cover.is-loading .wordmark, .sl-cover.is-loading .subtitle, .sl-cover.is-loading .credits,
+    .sl-cover.is-loading .members-head, .sl-cover.is-loading .member {
         opacity: 1 !important;
         filter: none !important;
         transform: none !important;

--- a/src/pages/Documentation/deck/slides/feedback1Slide.css
+++ b/src/pages/Documentation/deck/slides/feedback1Slide.css
@@ -25,6 +25,7 @@
 .sl-feedback-1 .eyebrow .bar { width: 46px; height: 1px; background: rgba(255,255,255,0.28); }
 .sl-feedback-1 .headline { font-family: var(--font-kr); font-size: 44px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.2; color: var(--text-primary); }
 .sl-feedback-1 .headline .accent { background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.sl-feedback-1 .note { font-family: var(--font-kr); font-size: 15px; font-weight: 500; color: var(--text-tertiary); margin-top: 10px; letter-spacing: 0.01em; }
 
 /* 3-column comparison */
 .sl-feedback-1 .cols { position: absolute; left: 96px; right: 96px; top: 296px; bottom: 64px; z-index: 5;
@@ -137,13 +138,14 @@
 .sl-feedback-1 .arrow.a2 { left: 1241px; }
 
 /* entrance */
-.sl-feedback-1 .corner, .sl-feedback-1 .eyebrow, .sl-feedback-1 .headline, .sl-feedback-1 .col {
+.sl-feedback-1 .corner, .sl-feedback-1 .eyebrow, .sl-feedback-1 .headline, .sl-feedback-1 .note, .sl-feedback-1 .col {
   transition-property: opacity, transform, filter; transition-duration: 0.85s; transition-timing-function: cubic-bezier(0.2,0.7,0.2,1);
 }
 .sl-feedback-1 .corner.left { transition-delay: 0.10s; }
 .sl-feedback-1 .corner.right { transition-delay: 0.16s; }
 .sl-feedback-1 .eyebrow { transition-delay: 0.16s; }
 .sl-feedback-1 .headline { transition-delay: 0.24s; }
+.sl-feedback-1 .note { transition-delay: 0.32s; }
 .sl-feedback-1 .col:nth-child(1) { transition-delay: 0.40s; }
 .sl-feedback-1 .col:nth-child(2) { transition-delay: 0.54s; }
 .sl-feedback-1 .col:nth-child(3) { transition-delay: 0.68s; }
@@ -151,11 +153,12 @@
 .sl-feedback-1.is-loading .corner { opacity: 0; transform: translateY(-12px); }
 .sl-feedback-1.is-loading .eyebrow { opacity: 0; transform: translateY(18px); }
 .sl-feedback-1.is-loading .headline { opacity: 0; transform: translateY(20px); filter: blur(8px); }
+.sl-feedback-1.is-loading .note { opacity: 0; transform: translateY(16px); }
 .sl-feedback-1.is-loading .col { opacity: 0; transform: translateY(26px); }
 .sl-feedback-1.is-loading .arrow { opacity: 0; }
 
 @media (prefers-reduced-motion: reduce) {
-  .sl-feedback-1 .corner, .sl-feedback-1 .eyebrow, .sl-feedback-1 .headline, .sl-feedback-1 .col, .sl-feedback-1 .arrow { transition: none !important; }
-  .sl-feedback-1.is-loading .corner, .sl-feedback-1.is-loading .eyebrow, .sl-feedback-1.is-loading .headline, .sl-feedback-1.is-loading .col, .sl-feedback-1.is-loading .arrow {
+  .sl-feedback-1 .corner, .sl-feedback-1 .eyebrow, .sl-feedback-1 .headline, .sl-feedback-1 .note, .sl-feedback-1 .col, .sl-feedback-1 .arrow { transition: none !important; }
+  .sl-feedback-1.is-loading .corner, .sl-feedback-1.is-loading .eyebrow, .sl-feedback-1.is-loading .headline, .sl-feedback-1.is-loading .note, .sl-feedback-1.is-loading .col, .sl-feedback-1.is-loading .arrow {
     opacity: 1 !important; transform: none !important; filter: none !important; }
 }

--- a/src/pages/Documentation/deck/useDeckPreload.ts
+++ b/src/pages/Documentation/deck/useDeckPreload.ts
@@ -1,0 +1,102 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import { DECK_IMAGE_URLS } from './deckAssets';
+import { DECK_FONT_SETS, ensureDeckFontStylesheet } from './deckFonts';
+
+/** 죽은 에셋 하나가 진입을 영원히 막지 않도록 하는 백스톱 */
+const PRELOAD_TIMEOUT_MS = 8000;
+
+export type DeckPreloadState = {
+    ready: boolean;
+    loaded: number;
+    total: number;
+};
+
+const TOTAL = DECK_IMAGE_URLS.length + DECK_FONT_SETS.length;
+
+// 모듈 레벨 싱글턴 — StrictMode 이중 이펙트에서 프리로드 1회 보장,
+// 재방문 시 게이트 즉시 통과(ready 유지).
+let loadedCount = 0;
+let done = false;
+let started: Promise<void> | null = null;
+let snapshot: DeckPreloadState = { ready: false, loaded: 0, total: TOTAL };
+const subscribers = new Set<() => void>();
+
+function notify() {
+    snapshot = { ready: done, loaded: loadedCount, total: TOTAL };
+    subscribers.forEach((fn) => fn());
+}
+
+function subscribe(fn: () => void) {
+    subscribers.add(fn);
+    return () => subscribers.delete(fn);
+}
+
+function getSnapshot(): DeckPreloadState {
+    return snapshot;
+}
+
+/** fetch뿐 아니라 디코드 캐시까지 워밍 — 슬라이드 도착 시 decode 태스크가 남지 않게 한다 */
+function preloadImage(url: string): Promise<void> {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.src = url;
+        img.decode().then(
+            () => resolve(),
+            () => {
+                // decode() 미지원/실패 시 load 이벤트로 폴백 (에러도 resolve — 타임아웃이 백스톱)
+                if (img.complete) {
+                    resolve();
+                    return;
+                }
+                img.onload = () => resolve();
+                img.onerror = () => resolve();
+            },
+        );
+    });
+}
+
+function startPreload(): Promise<void> {
+    if (started) return started;
+    started = (async () => {
+        const bump = () => {
+            loadedCount += 1;
+            notify();
+        };
+        const tasks: Promise<unknown>[] = [
+            ...DECK_IMAGE_URLS.map((url) => preloadImage(url).finally(bump)),
+            ...DECK_FONT_SETS.map(([spec, sample]) =>
+                ensureDeckFontStylesheet()
+                    .then(() => document.fonts.load(spec, sample))
+                    .then(
+                        () => undefined,
+                        () => undefined,
+                    )
+                    .finally(bump),
+            ),
+        ];
+        const outcome = await Promise.race([
+            Promise.allSettled(tasks).then(() => 'settled' as const),
+            new Promise<'timeout'>((resolve) => {
+                setTimeout(() => resolve('timeout'), PRELOAD_TIMEOUT_MS);
+            }),
+        ]);
+        if (outcome === 'timeout') {
+            console.warn(`[deck] preload timeout — ${TOTAL - loadedCount}/${TOTAL} tasks unfinished`);
+        }
+        done = true;
+        notify();
+    })();
+    return started;
+}
+
+/**
+ * 덱 진입 게이트용 프리로더 — 전 슬라이드 이미지(디코드 포함) + 폰트 세트를
+ * 모두 로드한 뒤 ready를 올린다. enabled=false(print 모드)면 즉시 ready.
+ */
+export function useDeckPreload(enabled: boolean): DeckPreloadState {
+    useEffect(() => {
+        if (enabled) void startPreload();
+    }, [enabled]);
+    const state = useSyncExternalStore(subscribe, getSnapshot);
+    return enabled ? state : { ready: true, loaded: state.loaded, total: state.total };
+}


### PR DESCRIPTION
## 개요
Production 첫 방문 시 덱 엔트런스 이펙트가 끊기는 문제(Cold Start)를 최적화 + 프리로드 게이트 하이브리드로 해결하고, 커버·Performance 섹션 콘텐츠를 수정합니다.

## 1. 콜드 스타트 최적화 + 프리로드 게이트 (`6f38fd5`)

**원인 진단**
- 대형 webp(최대 178KB)가 `loading="lazy"` + hidden 섹션 안 → 슬라이드 도착 순간 fetch/decode가 엔트런스와 충돌
- 폰트가 덱 마운트 시점에 주입 → 첫 엔트런스 중 FOUT/리플로우
- 전 슬라이드가 `blur()` 트랜지션인데 `will-change` 전무 → 첫 재생 시 컴포지터 레이어 즉석 래스터화
- 덱 청크·이미지·폰트 사전 워밍 부재

**해결**
- **진입 게이트**: 전 슬라이드 이미지 6종(decode 포함) + 폰트 13세트 로드 완료까지 진행률 바(n/m) 오버레이 표시, 8초 타임아웃 백스톱. `deckAssets.ts` 매니페스트로 프리로드 커버리지가 전 슬라이드와 구조적으로 일치함을 보장
- 오버레이 뒤에서 reveal을 먼저 init해 착지 슬라이드 레이어 사전 래스터화, 게이트 오픈 시 엔트런스 재생 (`#/n` 딥링크 대응, 게이트 중 키보드 잠금)
- `will-change`는 근접 슬라이드(현재 ±1, `pf-near`)로 한정해 GPU 메모리 억제
- `loading="lazy"` 7곳 제거, DocsPage 유휴 시 덱 청크 프리페치 + 카드 호버 시 이미지·폰트 워밍
- 폰트 URL에 Poppins 300 추가 (기존 400 대체 렌더링 복원)

## 2. 콘텐츠 수정 (`580bd72`)
- 커버: 서브타이틀 아래 `PPT 김태현 · PRESENTER 박준우` 크레딧 라인 (엔트런스 스태거 편입)
- 15번: corner `05 • Feedback` → `05 • Performance`, 회색 주석 `* 포트폴리오의 특정 개선 영역만 발췌` 추가
- 16번: corner `06` → `05` — 목차 체계(05 Performance / 06 Q&A)와 정합

## 검증
- headless Chromium E2E 22개 체크 전부 통과: 콜드 진입 게이트 동작, 전 리소스 로드 후 엔트런스 재생, `#/7` 딥링크, `?print-pdf` 17페이지, 오버뷰 모드, DocsPage 프리페치, dev(StrictMode) 이중 마운트
- `npm run build`(tsc 포함) 통과, DeckPage 청크 분리 유지
- 커버·15·16번 변경은 프로덕션 빌드 스크린샷으로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)