### PR TITLE
feat: 서비스 점검 모드 + 중단 공지 + 서비스 이메일 일원화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import { TooManyRequestsPage } from '@/pages/Error/TooManyRequestsPage';
 import { ServerErrorPage } from '@/pages/Error/ServerErrorPage';
 import { PrivateRoute } from '@/components/Auth/PrivateRoute';
 import { AdminRoute } from '@/components/Auth/AdminRoute';
+import { MaintenanceRoute } from '@/components/Maintenance/MaintenanceRoute';
+import { MaintenancePage } from '@/pages/Maintenance/MaintenancePage';
 import { ErrorBoundary } from '@/components/Error/ErrorBoundary';
 import { AuthProvider } from '@/context/Auth/AuthContext';
 import { Header } from "@/components/Layout/Header/Header";
@@ -70,15 +72,12 @@ export const App = () => {
                 <ScrollToTopOnPathChange />
                 {!isChromelessRoute && <Header />}
                 <Routes>
-                    {/* --- 공개 라우트 --- */}
+                    {/* --- 공개 라우트 (정적 — 서버 API 미의존, 점검 모드에서도 접근 가능) --- */}
                     <Route path="/" element={<LanderPage />} />
                     <Route path="/announcements" element={<AnnouncementsPage />} />
-                    <Route path="/articles" element={<ArticleListPage />} />
-                    <Route path="/articles/:id" element={<ArticleDetailPage />} />
                     <Route path="/faq" element={<FaqPage />} />
                     <Route path="/terms" element={<TermsOfServicePage />} />
                     <Route path="/privacy" element={<PrivacyPolicyPage />} />
-                    <Route path="/roadmap" element={<RoadMapPage />} />
                     <Route path="/docs" element={<DocsPage />} />
                     <Route
                         path="/docs/passfolio-deck"
@@ -88,11 +87,7 @@ export const App = () => {
                             </Suspense>
                         }
                     />
-                    <Route path="/oauth/callback" element={<OAuthCallback />} />
-
-                    {/* Hidden: 관리자 포털(네비에 링크 없음, URL 직접 입력) */}
-                    <Route path={ADMIN_PORTAL_LOGIN_PATH} element={<AdminLoginPage />} />
-                    <Route path={ADMIN_PORTAL_SIGNUP_PATH} element={<AdminSignupPage />} />
+                    <Route path="/maintenance" element={<MaintenancePage />} />
 
                     {/* --- 에러 페이지 --- */}
                     <Route path="/400" element={<BadRequestPage />} />
@@ -102,27 +97,42 @@ export const App = () => {
                     <Route path="/429" element={<TooManyRequestsPage />} />
                     <Route path="/500" element={<ServerErrorPage />} />
 
-                    {/* --- 비공개 라우트 --- */}
-                    <Route element={<PrivateRoute />}>
-                        <Route path="/profile" element={<UserProfileRoute />} />
-                        <Route path="/analysis/:batchId" element={<AnalysisProgressPage />} />
-                        <Route
-                            path="/analysis/report/:analysisId"
-                            element={
-                                <Suspense fallback={null}>
-                                    <AnalysisReportPage />
-                                </Suspense>
-                            }
-                        />
-                        <Route path="/upload" element={<UploadPage />} />
-                        <Route element={<AdminRoute />}>
-                            <Route path={ADMIN_PORTAL_PROFILE_PATH} element={<AdminProfilePage />} />
-                            <Route path={ADMIN_PORTAL_TEST_PATH} element={<AdminTestPage />} />
-                            <Route path={ADMIN_PORTAL_ANALYSIS_METRICS_PATH} element={<AdminAnalysisMetricsPage />} />
-                            <Route path={ADMIN_PORTAL_USERS_PATH} element={<AdminUsersPage />} />
-                            <Route path={ADMIN_PORTAL_PRECHECK_TEST_PATH} element={<AdminPrecheckTestPage />} />
-                            <Route path="/articles/create" element={<ArticleCreatePage />} />
-                            <Route path="/articles/:id/edit" element={<ArticleEditPage />} />
+                    {/* ── 서비스 점검 대상 ──────────────────────────────
+                        서버 API를 호출하는 라우트는 전부 이 블록 안에 둔다.
+                        VITE_SERVICE_MAINTENANCE=true면 일괄 /maintenance로 리다이렉트.
+                        새 API 의존 페이지 추가 시 반드시 이 블록 안에 배치할 것. */}
+                    <Route element={<MaintenanceRoute />}>
+                        <Route path="/articles" element={<ArticleListPage />} />
+                        <Route path="/articles/:id" element={<ArticleDetailPage />} />
+                        <Route path="/roadmap" element={<RoadMapPage />} />
+                        <Route path="/oauth/callback" element={<OAuthCallback />} />
+
+                        {/* Hidden: 관리자 포털(네비에 링크 없음, URL 직접 입력) */}
+                        <Route path={ADMIN_PORTAL_LOGIN_PATH} element={<AdminLoginPage />} />
+                        <Route path={ADMIN_PORTAL_SIGNUP_PATH} element={<AdminSignupPage />} />
+
+                        {/* --- 비공개 라우트 --- */}
+                        <Route element={<PrivateRoute />}>
+                            <Route path="/profile" element={<UserProfileRoute />} />
+                            <Route path="/analysis/:batchId" element={<AnalysisProgressPage />} />
+                            <Route
+                                path="/analysis/report/:analysisId"
+                                element={
+                                    <Suspense fallback={null}>
+                                        <AnalysisReportPage />
+                                    </Suspense>
+                                }
+                            />
+                            <Route path="/upload" element={<UploadPage />} />
+                            <Route element={<AdminRoute />}>
+                                <Route path={ADMIN_PORTAL_PROFILE_PATH} element={<AdminProfilePage />} />
+                                <Route path={ADMIN_PORTAL_TEST_PATH} element={<AdminTestPage />} />
+                                <Route path={ADMIN_PORTAL_ANALYSIS_METRICS_PATH} element={<AdminAnalysisMetricsPage />} />
+                                <Route path={ADMIN_PORTAL_USERS_PATH} element={<AdminUsersPage />} />
+                                <Route path={ADMIN_PORTAL_PRECHECK_TEST_PATH} element={<AdminPrecheckTestPage />} />
+                                <Route path="/articles/create" element={<ArticleCreatePage />} />
+                                <Route path="/articles/:id/edit" element={<ArticleEditPage />} />
+                            </Route>
                         </Route>
                     </Route>
 

--- a/src/components/Layout/Header/ProfileDropdownMenu.tsx
+++ b/src/components/Layout/Header/ProfileDropdownMenu.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import type { UserType } from '@/context/Auth/AuthContext';
 import { ADMIN_PORTAL_PROFILE_PATH } from '@/constants/adminPortal';
+import { SERVICE_EMAIL } from '@/constants/service';
 import { useClickOutside } from '@/hooks/useClickOutside';
 
 type ProfileDropdownMenuProps = {
@@ -121,10 +122,10 @@ export const ProfileDropdownMenu = ({
 
             {/* 고객센터 / 의견 보내기 */}
             <div className="px-1.5 py-1">
-                <ExternalLink href="mailto:support@passfolio.kr" onClick={onClose}>
+                <ExternalLink href={`mailto:${SERVICE_EMAIL}`} onClick={onClose}>
                     고객센터
                 </ExternalLink>
-                <ExternalLink href="mailto:feedback@passfolio.kr" onClick={onClose}>
+                <ExternalLink href={`mailto:${SERVICE_EMAIL}`} onClick={onClose}>
                     의견 보내기
                 </ExternalLink>
             </div>

--- a/src/components/Maintenance/MaintenanceRoute.tsx
+++ b/src/components/Maintenance/MaintenanceRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { IS_SERVICE_MAINTENANCE } from '@/constants/maintenance';
+
+/**
+ * 서비스 점검 가드 — 점검 모드(VITE_SERVICE_MAINTENANCE=true)일 때
+ * 하위 라우트 접근을 /maintenance로 리다이렉트한다.
+ *
+ * 점검 대상 라우트는 App.tsx의 <Route element={<MaintenanceRoute />}> 블록
+ * 한 곳에서만 관리한다 (페이지별 개별 적용 금지 — 유지보수 일원화).
+ */
+export const MaintenanceRoute = () => {
+    if (IS_SERVICE_MAINTENANCE) {
+        return <Navigate to="/maintenance" replace />;
+    }
+    return <Outlet />;
+};

--- a/src/constants/landingPage.ts
+++ b/src/constants/landingPage.ts
@@ -1,6 +1,8 @@
 import landingJdAnalysisImageSrc from '@/assets/image/jd-analysis-optimized.png';
 import landingPortfolioImageSrc from '@/assets/image/portfolio-optimized.png';
 import landingProjectReportImageSrc from '@/assets/image/project-report.png';
+import { SERVICE_EMAIL } from '@/constants/service';
+import { guardHrefForMaintenance } from '@/constants/maintenance';
 
 function trimEnv(value: string | undefined): string {
   return value?.trim() ?? '';
@@ -83,12 +85,15 @@ export const LANDING_HERO_SECTION = {
   titleGradient: 'Developer Portfolio',
   description: 'GitHub 연동을 통한 프로젝트 및 기여도 분석, 맞춤형 공고 기반 포트폴리오 생성까지.',
   descriptionSubtext: '당신의 개발자 역량을 증명하는 가장 체계적인 솔루션.',
+  // 두 CTA 모두 최종적으로 서버(OAuth 등)를 경유하므로 점검 모드에서는 /maintenance로 우회
   primaryCta: {
-    href: getOptionalLandingHref(import.meta.env.VITE_LANDING_PRIMARY_CTA_HREF),
+    href: guardHrefForMaintenance(
+      getOptionalLandingHref(import.meta.env.VITE_LANDING_PRIMARY_CTA_HREF),
+    ),
     label: 'Start Free Trial',
   },
   secondaryCta: {
-    href: getLandingGitHubCtaHref(),
+    href: guardHrefForMaintenance(getLandingGitHubCtaHref()),
     label: 'Connect GitHub',
   },
 } as const satisfies {
@@ -275,7 +280,8 @@ export function getLandingFooterInfoSegments(): LandingFooterInfoSegmentsType {
   );
   const address = trimEnv(import.meta.env.VITE_FOOTER_ADDRESS);
   const phone = trimEnv(import.meta.env.VITE_FOOTER_CONTACT_PHONE);
-  const email = trimEnv(import.meta.env.VITE_FOOTER_CONTACT_EMAIL);
+  // 푸터 문의 이메일도 서비스 대표 이메일(VITE_SERVICE_EMAIL)로 일원화
+  const email = SERVICE_EMAIL;
 
   const firstLineList = [
     withRepresentativeLabel(representativeName),

--- a/src/constants/maintenance.ts
+++ b/src/constants/maintenance.ts
@@ -1,0 +1,20 @@
+/**
+ * 서비스 점검 모드 — true면 서버 API 의존 라우트(App.tsx의 MaintenanceRoute 블록)가
+ * /maintenance로 일괄 리다이렉트된다. 정적 페이지(랜딩·공지·Docs·약관 등)는 대상 아님.
+ *
+ * 제어: .env(로컬) 및 배포 환경 빌드 변수의 VITE_SERVICE_MAINTENANCE ('true' | 'false')
+ * 기본값: false (변수 미설정 시)
+ *
+ * 주의: Vite는 `import.meta.env.VITE_*` 정적 리터럴만 빌드 타임에 치환하므로
+ * 동적 키 접근(import.meta.env[key])으로 바꾸지 말 것.
+ */
+export const IS_SERVICE_MAINTENANCE = import.meta.env.VITE_SERVICE_MAINTENANCE === 'true';
+
+/**
+ * 점검 모드면 서버를 경유하는 링크(href)를 /maintenance로 우회시킨다.
+ * 라우트 단위 차단은 App.tsx의 MaintenanceRoute 블록이 담당하고,
+ * 이 헬퍼는 라우터 밖 링크(OAuth 리다이렉트 CTA 등)에 사용한다.
+ */
+export function guardHrefForMaintenance(href: string): string {
+    return IS_SERVICE_MAINTENANCE ? '/maintenance' : href;
+}

--- a/src/constants/service.ts
+++ b/src/constants/service.ts
@@ -1,0 +1,5 @@
+/**
+ * 서비스 대표 문의 이메일 — .env(로컬) 및 배포 환경 빌드 변수의 VITE_SERVICE_EMAIL로 제어.
+ * 점검 안내·공지사항·고객센터/의견 보내기 mailto·개인정보 보호책임자·푸터 문의 표기에 사용된다.
+ */
+export const SERVICE_EMAIL = import.meta.env.VITE_SERVICE_EMAIL?.trim() || 'hooby@passfolio.dev';

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -1,3 +1,5 @@
+import { SERVICE_EMAIL } from '@/constants/service';
+
 /** 공지사항 (추후 CMS/API 연동 시 교체) */
 export type AnnouncementItemType = {
   id: string;
@@ -13,6 +15,20 @@ export type AnnouncementItemType = {
 };
 
 export const ANNOUNCEMENT_LIST: AnnouncementItemType[] = [
+  {
+    id: '2026-07-04-service-pause',
+    date: '2026-07-04',
+    title: 'Passfolio 서비스 일시 중단 및 정식 출시 예고 안내',
+    summary: '서버 운영 비용 이슈로 서비스를 일시 중단하며, 2026년 12월 정식 출시를 목표로 재정비합니다.',
+    pinned: true,
+    // 문단 내 줄바꿈(\n)은 AnnouncementsPage의 whitespace-pre-line으로 렌더링된다
+    paragraphs: [
+      '안녕하십니까, Passfolio 운영자 김태현입니다.\n본 서비스는 명지대학교(자연) 캡스톤 디자인의 프로젝트입니다.\n2026.06.07 이후 전체 일정을 끝마쳤고, 서버 운영 비용의 이슈로 잠시 중단할 예정입니다.',
+      '당분간 운영진은 백엔드와 AI LLM, DevOps 등 개발 공부를 통해 내실을 다질 예정입니다.\n보다 더 비용 효율적이고 최적화된 설계, UX 및 협업적 친화 개발을 위해 성장해서 돌아올 생각입니다.',
+      `정식 출시는 2026년 12월부터 진행하고자 합니다.\n보다 더 나은 UX를 위해 고민하고, 현재보다 더 실용적인 방향으로 기능 업그레이드 및 확장해서 돌아오겠습니다.\n문의사항 있으시면, ${SERVICE_EMAIL}으로 문의해주시길 바랍니다.`,
+      '감사합니다.',
+    ],
+  },
   {
     id: '2026-04-01-service',
     date: '2026-04-01',

--- a/src/data/privacyPolicy.ts
+++ b/src/data/privacyPolicy.ts
@@ -1,3 +1,5 @@
+import { SERVICE_EMAIL } from '@/constants/service';
+
 /** 개인정보 처리방침 (법무 검토 후 확정 권장) */
 
 export type PrivacySectionType = {
@@ -276,7 +278,7 @@ export const PRIVACY_SECTION_LIST: PrivacySectionType[] = [
       '· 성명: 김태현',
       '· 직책: CTO',
       '· 전화번호: 010-9726-1322',
-      '· 이메일: dev.youcu@gmail.com',
+      `· 이메일: ${SERVICE_EMAIL}`,
     ],
   },
   {

--- a/src/pages/Announcements/AnnouncementsPage.tsx
+++ b/src/pages/Announcements/AnnouncementsPage.tsx
@@ -16,7 +16,7 @@ export function AnnouncementsPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-[#0d0d0f] text-white">
-      <main className="relative z-[1] mx-auto w-full max-w-[720px] flex-1 px-4 pb-20 pt-24 md:px-6 md:pt-28">
+      <main className="relative z-[1] mx-auto w-full max-w-[960px] flex-1 px-4 pb-20 pt-24 md:px-6 md:pt-28">
         <header className="mb-10 md:mb-12">
           <p className="text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-zinc-500">Notice</p>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white md:text-4xl">공지사항</h1>
@@ -54,7 +54,7 @@ export function AnnouncementsPage() {
                 <p className="mt-2 text-sm text-zinc-400">{item.summary}</p>
                 <div className="mt-4 space-y-3 border-t border-white/[0.06] pt-4">
                   {item.paragraphs.map((p, i) => (
-                    <p key={i} className="text-[0.92rem] leading-relaxed text-zinc-300">
+                    <p key={i} className="whitespace-pre-line text-[0.92rem] leading-relaxed text-zinc-300">
                       {p}
                     </p>
                   ))}

--- a/src/pages/Error/ErrorLayout.tsx
+++ b/src/pages/Error/ErrorLayout.tsx
@@ -50,7 +50,8 @@ export function ErrorLayout({
                 >
                     <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
                     <h2 className="text-xl font-semibold tracking-tight text-white">{title}</h2>
-                    <p className="mt-2 text-sm leading-relaxed text-zinc-400">{description}</p>
+                    {/* whitespace-pre-line: description의 \n을 줄바꿈으로 렌더 (기존 문구는 \n이 없어 무영향) */}
+                    <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-zinc-400">{description}</p>
                 </div>
 
                 <div className="mt-8 flex flex-wrap justify-center gap-3">

--- a/src/pages/Maintenance/MaintenancePage.tsx
+++ b/src/pages/Maintenance/MaintenancePage.tsx
@@ -1,0 +1,25 @@
+import { Navigate, useNavigate } from 'react-router-dom';
+import { ErrorLayout } from '@/pages/Error/ErrorLayout';
+import { IS_SERVICE_MAINTENANCE } from '@/constants/maintenance';
+import { SERVICE_EMAIL } from '@/constants/service';
+
+/** 서비스 점검 안내 페이지 — 점검 모드에서 API 의존 라우트가 이곳으로 리다이렉트된다 */
+export function MaintenancePage() {
+    const navigate = useNavigate();
+
+    // 점검 모드가 아닐 때의 직접 접근(북마크 등)은 홈으로 — 점검 종료 후 잔류 방지
+    if (!IS_SERVICE_MAINTENANCE) {
+        return <Navigate to="/" replace />;
+    }
+
+    return (
+        <ErrorLayout
+            code="503"
+            label="Service Maintenance"
+            title="서비스 점검 중입니다"
+            description={`현재 서비스가 일시 중단 상태입니다.\n자세한 일정과 배경은 공지사항에서 확인하실 수 있습니다.\n문의: ${SERVICE_EMAIL}`}
+            primaryAction={{ label: '공지사항 보기', onClick: () => navigate('/announcements') }}
+            secondaryAction={{ label: '홈으로', onClick: () => navigate('/') }}
+        />
+    );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,11 +10,14 @@ interface ImportMetaEnv {
   readonly VITE_FOOTER_JOB_INFO_SERVICE_REPORT_NUMBER?: string;
   readonly VITE_FOOTER_ADDRESS?: string;
   readonly VITE_FOOTER_CONTACT_PHONE?: string;
-  readonly VITE_FOOTER_CONTACT_EMAIL?: string;
   readonly VITE_ADMIN_PORTAL_LOGIN_PATH?: string;
   readonly VITE_ADMIN_PORTAL_SIGNUP_PATH?: string;
   readonly VITE_ADMIN_PORTAL_PROFILE_PATH?: string;
   readonly VITE_ADMIN_PORTAL_TEST_PATH?: string;
+  /** 'true'면 서비스 점검 모드 — API 의존 라우트가 /maintenance로 리다이렉트된다 */
+  readonly VITE_SERVICE_MAINTENANCE?: string;
+  /** 서비스 대표 문의 이메일 (점검 안내·공지·고객센터 mailto 등에 표시) */
+  readonly VITE_SERVICE_EMAIL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 개요
서버(Spring) 임시 중단 상태를 사용자에게 알리기 위한 대응 묶음입니다. 점검 모드는 추후 서버 점검 시에도 재활용합니다.

## 1. 서비스 점검 모드 (`2e3d057`)
- `VITE_SERVICE_MAINTENANCE=true`(빌드 환경변수)면 **서버 API를 호출하는 라우트만** `/maintenance`로 리다이렉트. 정적 페이지(랜딩·공지·Docs·FAQ·약관·개인정보·에러)는 접근 유지
- **점검 대상은 App.tsx의 `<Route element={<MaintenanceRoute />}>` 블록 한 곳에서만 관리** — 새 API 의존 라우트는 이 블록 안에 배치하는 규칙을 주석으로 명시
- `MaintenancePage`: 기존 `ErrorLayout` 재사용(503 톤 일관), 개행 문구 + '공지사항 보기'/'홈으로' 버튼, 플래그 off 시 직접 접근은 홈으로 귀환
- 랜딩 `Start Free Trial`·`Connect GitHub` CTA는 서버(OAuth)를 경유하므로 `guardHrefForMaintenance` 헬퍼로 우회 (헤더에는 로그인 버튼이 없음을 전수 확인)
- 서비스 문의 이메일을 `VITE_SERVICE_EMAIL`(기본 `hooby@passfolio.dev`)로 일원화: 점검 페이지·고객센터/의견 보내기 mailto·개인정보 보호책임자·푸터 문의 (`VITE_FOOTER_CONTACT_EMAIL` 키 제거)

## 2. 서비스 중단 공지 (`c70fa46`)
- 공지사항에 서비스 일시 중단 및 2026년 12월 정식 출시 예고 공지 추가 (고정, 2026-07-04)
- 본문 4개 문단 그룹핑(`\n` + `whitespace-pre-line`), 콘텐츠 폭 720→960px

## 검증 (headless Chromium 실측)
- flag=true: `/articles`·`/roadmap`·`/oauth/callback`·`/profile`·`/upload` 등 → `/maintenance` 착지, 정적 페이지는 리다이렉트 없음, CTA 2개 href=`/maintenance`
- flag=false: `/articles` 정상 진입, `/maintenance` 직접 접근 → `/` 귀환
- 390/768/1440 반응형 가로 오버플로 없음, 공지 4문단·960px 실측 확인, `npm run build`(tsc) 통과

## 배포 참고
Cloudflare Pages 빌드 환경변수에 `VITE_SERVICE_MAINTENANCE=true`, `VITE_SERVICE_EMAIL=hooby@passfolio.dev` 등록 필요 (.env는 로컬 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)