### PR TITLE
fix(lander): 랜딩 .reveal 클래스와 reveal.js 전역 CSS 충돌 해결

### DIFF
--- a/src/components/Lander/landingHeroSection.tsx
+++ b/src/components/Lander/landingHeroSection.tsx
@@ -18,20 +18,20 @@ export const LandingHeroSection = () => {
     <section className="hero" aria-labelledby="landing-hero-title">
       <div className="hero-glow" aria-hidden />
 
-      <div className={`hero-content reveal ${isHeroReady ? 'active' : ''}`}>
-        <div className={`hero-badge reveal delay-100 ${isHeroReady ? 'active' : ''}`}>
+      <div className={`hero-content scroll-reveal ${isHeroReady ? 'active' : ''}`}>
+        <div className={`hero-badge scroll-reveal delay-100 ${isHeroReady ? 'active' : ''}`}>
           {LANDING_HERO_SECTION.badge}
         </div>
-        <h1 id="landing-hero-title" className={`reveal delay-200 ${isHeroReady ? 'active' : ''}`}>
+        <h1 id="landing-hero-title" className={`scroll-reveal delay-200 ${isHeroReady ? 'active' : ''}`}>
           {LANDING_HERO_SECTION.titlePrefix}
           <br />
           <span className="text-gradient">{LANDING_HERO_SECTION.titleGradient}</span>
         </h1>
-        <p className={`reveal delay-300 ${isHeroReady ? 'active' : ''}`}>
+        <p className={`scroll-reveal delay-300 ${isHeroReady ? 'active' : ''}`}>
           {LANDING_HERO_SECTION.description}
           <span className="subtitle-block">{LANDING_HERO_SECTION.descriptionSubtext}</span>
         </p>
-        <div className={`btn-group reveal delay-300 ${isHeroReady ? 'active' : ''}`}>
+        <div className={`btn-group scroll-reveal delay-300 ${isHeroReady ? 'active' : ''}`}>
           <a
             href={LANDING_HERO_SECTION.primaryCta.href}
             className="btn btn-primary"

--- a/src/hooks/Layout/useRevealOnScroll.ts
+++ b/src/hooks/Layout/useRevealOnScroll.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
-const REVEAL_SELECTOR = '.reveal, .reveal-left, .reveal-left-how, .reveal-up';
+// bare `.reveal`은 reveal.js(덱) 컨테이너 클래스와 충돌해 `.scroll-reveal`로 rename됨
+const REVEAL_SELECTOR = '.scroll-reveal, .reveal-left, .reveal-left-how, .reveal-up';
 
 export function useRevealOnScroll<T extends HTMLElement>(watchKey?: string | number) {
   const rootRef = useRef<T>(null);

--- a/src/pages/Documentation/deck/deck.css
+++ b/src/pages/Documentation/deck/deck.css
@@ -45,14 +45,11 @@
     padding: 0;
     text-align: left;
 }
+/* landerPage.css의 스크롤-리빌 유틸리티는 .scroll-reveal로 rename되어
+   reveal.js 컨테이너 클래스(.reveal)와 더 이상 충돌하지 않는다 */
 .pf-deck .reveal {
     width: 100%;
     height: 100%;
-    /* landerPage.css의 스크롤-리빌 유틸리티(.reveal { opacity:0; translateY })와
-       reveal.js 컨테이너 클래스가 충돌 — 덱 안에서는 무력화한다 */
-    opacity: 1;
-    transform: none;
-    transition: none;
 }
 /* reveal은 뷰포트 클래스를 body에 붙인다 (덱 활성 중에만 존재) */
 body.reveal-viewport {

--- a/src/pages/Lander/landerPage.css
+++ b/src/pages/Lander/landerPage.css
@@ -413,7 +413,9 @@
     color: #ffffff !important;
   }
 
-  .reveal {
+  /* 스크롤-리빌 유틸리티 — reveal.js(덱)의 전역 .reveal 컨테이너 클래스와
+     충돌하므로 bare `reveal`이 아닌 `scroll-reveal`을 사용한다 */
+  .scroll-reveal {
     opacity: 0;
     transform: translateY(40px);
     transition:
@@ -422,7 +424,7 @@
     will-change: opacity, transform;
   }
 
-  .reveal.active {
+  .scroll-reveal.active {
     opacity: 1;
     transform: translateY(0);
   }


### PR DESCRIPTION
## 1️⃣. 작업 내용

랜딩 페이지의 `.reveal` 스크롤-리빌 유틸리티 클래스와 reveal.js(웹 PPT 덱) 전역 CSS의 클래스 이름 충돌 버그 수정입니다.

**버그**: 헤더에서 Documentation(/docs) 이동 후 로고 클릭으로 랜딩 복귀 시, 히어로 배지가 화면 전체 폭으로 늘어지는 등 레이아웃 파손.

**원인**:
- 랜딩 히어로가 bare `reveal` 클래스를 사용(5곳)하는데, 덱 청크에 포함된 reveal.js CSS가 `.reveal { position:relative; width:100%; height:100%; overflow:hidden; … }` 등 전역 `.reveal` 셀렉터를 정의
- `/docs`의 덱 청크 idle 프리페치(#47)가 reveal.js CSS를 전역 주입 → 랜딩 복귀 시 히어로 `.reveal` 요소에 라이브러리 규칙이 적용되어 파손
- 덱 도입 시점부터 잠재하던 충돌(덱 직접 방문 후 랜딩 복귀 시에도 동일)이 프리페치로 표면화된 것

**수정 (root fix)**:
- 랜딩 유틸리티를 `reveal` → `scroll-reveal`로 rename: `landerPage.css` 정의, `landingHeroSection.tsx` 사용처 5곳, `useRevealOnScroll.ts` 옵저버 셀렉터 (`reveal-up`/`reveal-left` 계열은 이름이 겹치지 않아 유지)
- rename으로 불필요해진 `deck.css`의 역방향 무력화 3줄(`.pf-deck .reveal { opacity:1; transform:none; transition:none; }`) 제거

## 2️⃣. 테스트 결과

headless Chromium(production build, `npm run preview`) 실측 — **fail-first 방식으로 수정 전 재현을 먼저 확인 후 수정**:

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| `/docs` 진입 → 3초 대기(idle 프리페치) → 로고 클릭 → 랜딩 복귀 → 히어로 배지 실측 폭 | **900px (컨테이너 전체 폭, 버그)** | **195px (정상)** ✅ |
| 랜딩 가로 오버플로 | 없음 | 없음 ✅ |
| 히어로 페이드인(opacity 1 도달) | — | 정상 ✅ |
| [회귀] 랜딩 스크롤-리빌 섹션(reveal-up/left → active 전환) | — | 정상 ✅ |
| [회귀] 덱(/docs/passfolio-deck) 프리로드 게이트 + 커버 엔트런스 | — | 정상 ✅ |

총 7/7 통과, `npm run build`(tsc 포함) 통과.

**테스트 시나리오 (수동 재현 절차)**:
1. 랜딩(/) 접속 → 헤더에서 Documentation 클릭 → `/docs`에서 3초 이상 대기
2. 헤더 Passfolio 로고 클릭으로 랜딩 복귀
3. 히어로의 `AI-POWERED BUILDER` 배지가 콘텐츠 크기의 작은 필로 표시되면 정상 (버그 시 화면 전체 폭으로 늘어남)

## 3️⃣. 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (headless Chromium 재현+회귀 7건)
- [x] 문서를 작성하거나 수정했나요? (충돌 배경을 landerPage.css·useRevealOnScroll·deck.css 주석으로 명시)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (별도 이슈 없음 — 운영 중 직접 발견)

## 4️⃣. 스크린샷 (선택)

- 버그 재현: 히어로 배지 필이 컨테이너 전체 폭(900px)으로 늘어남
- 수정 후: 배지가 텍스트 크기(195px)의 필로 정상 표시 (로컬 재검증 스크린샷 확인 완료)

## 5️⃣. 리뷰 요구사항 (선택)

- `deck.css`에서 제거한 무력화 3줄은 lander→deck 방향 충돌 대응이었는데, rename으로 충돌 자체가 사라져 불필요해졌습니다. 덱 페이지 렌더에 부작용이 없음을 회귀 테스트로 확인했으나, 덱 쪽도 한 번 훑어봐 주시면 좋겠습니다.
- bare `reveal` 사용처가 히어로 5곳뿐임은 grep 전수 조사로 확인했습니다.

## 📎 참고 자료 (선택)

- reveal.js 전역 CSS: `node_modules/reveal.js/dist/reveal.css`의 `.reveal` 컨테이너 셀렉터군
- 관련 PR: #47 (덱 프리로드 게이트 — idle 프리페치 도입), #46 (덱 최초 도입)

🤖 Generated with [Claude Code](https://claude.com/claude-code)