### PR TITLE
fix(deck): Safari에서 커버 워드마크·Q&A blur 고착 해결

### DIFF
--- a/src/pages/Documentation/deck/slides/coverSlide.css
+++ b/src/pages/Documentation/deck/slides/coverSlide.css
@@ -112,7 +112,9 @@
     background-clip: text;
     -webkit-text-fill-color: transparent;
     color: transparent;
-    filter: drop-shadow(0 6px 30px rgba(255, 255, 255, 0.07));
+    /* blur(0) 명시: is-loading의 blur(9px)와 filter 함수 리스트를 일치시켜
+       Safari가 discrete 전환에서 blur 상태로 고착되는 문제 방지 */
+    filter: blur(0) drop-shadow(0 6px 30px rgba(255, 255, 255, 0.07));
 }
 
 .sl-cover .subtitle {
@@ -263,7 +265,7 @@
 .sl-cover.is-loading .members-head,
 .sl-cover.is-loading .member { opacity: 0; transform: translateY(22px); }
 .sl-cover.is-loading .logo-mark { opacity: 0; transform: translateY(26px) scale(0.94); filter: blur(9px); }
-.sl-cover.is-loading .wordmark  { opacity: 0; transform: translateY(26px); filter: blur(9px); }
+.sl-cover.is-loading .wordmark  { opacity: 0; transform: translateY(26px); filter: blur(9px) drop-shadow(0 6px 30px rgba(255, 255, 255, 0.07)); }
 
 /* refined light glint sweeping across the wordmark letters, one pass */
 .sl-cover .wordmark { position: relative; }

--- a/src/pages/Documentation/deck/slides/qnaSlide.css
+++ b/src/pages/Documentation/deck/slides/qnaSlide.css
@@ -29,7 +29,9 @@
 .sl-qna .qa {
   font-family: var(--font-display); font-weight: 700; font-size: 280px; line-height: 0.92; letter-spacing: -0.04em;
   background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent;
-  filter: drop-shadow(0 10px 60px rgba(255,255,255,0.1));
+  /* blur(0) 명시: is-loading의 blur(10px)와 filter 함수 리스트를 일치시켜
+     Safari가 discrete 전환에서 blur 상태로 고착되는 문제 방지 */
+  filter: blur(0) drop-shadow(0 10px 60px rgba(255,255,255,0.1));
 }
 .sl-qna .sub { margin-top: 30px; display: flex; align-items: center; gap: 20px;
   font-family: var(--font-display); font-size: 26px; font-weight: 500; letter-spacing: 0.3em; text-transform: uppercase; color: var(--text-secondary); }
@@ -41,7 +43,7 @@
 .sl-qna .qa { transition-delay: 0.22s; }
 .sl-qna .sub { transition-delay: 0.5s; }
 .sl-qna.is-loading .corner { opacity: 0; transform: translateY(-12px); }
-.sl-qna.is-loading .qa { opacity: 0; transform: translateY(24px) scale(0.96); filter: blur(10px); }
+.sl-qna.is-loading .qa { opacity: 0; transform: translateY(24px) scale(0.96); filter: blur(10px) drop-shadow(0 10px 60px rgba(255,255,255,0.1)); }
 .sl-qna.is-loading .sub { opacity: 0; transform: translateY(16px); }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 1️⃣. 작업 내용

Safari에서 덱(/docs/passfolio-deck)의 커버 워드마크("Passfolio")와 Q&A 헤드라인이 엔트런스 이후에도 뿌옇게(blur) 남는 버그 수정입니다. Chrome은 정상이었습니다.

**원인**:
- 두 요소만 base 상태에 `filter: drop-shadow(…)`를 갖고, 엔트런스 시작 상태는 `filter: blur(9~10px)`
- CSS 스펙상 filter 전환은 함수 리스트가 같아야 연속 보간되며, `blur` ↔ `drop-shadow`는 리스트 불일치 → discrete 전환. Safari(WebKit)가 이 케이스에서 시작 상태(blur)를 렌더에 고착시킴
- 반증: base filter가 없는 로고·headline류는 `blur → none` 보간이 스펙에 정의돼 있어 Safari에서도 선명 — 증상 스크린샷의 선명/뿌염 패턴과 정확히 일치

**수정** (`coverSlide.css`·`qnaSlide.css` 각 2곳):
- base: `filter: blur(0) drop-shadow(…)` / 엔트런스: `filter: blur(N) drop-shadow(…)` — 동일 함수 리스트로 매칭해 모든 브라우저에서 연속 보간. `blur(0)`은 시각적 no-op이라 결과물 무변화

## 2️⃣. 테스트 결과

| 항목 | 결과 |
|---|---|
| 실기기 Safari (26.5) — 커버 워드마크·Q&A 선명 | ✅ 로컬 preview로 육안 확인 |
| Chromium — blur-in 엔트런스 연출 유지 + 최종 선명, computed filter 매칭 리스트 적용 | ✅ |
| Playwright WebKit 26.5 — 선명 유지 (해당 엔진 버전은 버그 자체가 미재현) | ✅ |
| `npm run build` (tsc 포함) | ✅ |

**테스트 시나리오 (수동 재현 절차)**:
1. Safari에서 `/docs/passfolio-deck` 진입 → 로딩 게이트 통과 후 커버 확인
2. 수정 전: "Passfolio" 워드마크가 뿌옇게 고착 / 수정 후: 엔트런스 blur-in 후 선명
3. 마지막 슬라이드(`#/16`, Q&A)도 동일 확인

## 3️⃣. 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (Safari 육안 + Chromium/WebKit 헤드리스)
- [x] 문서를 작성하거나 수정했나요? (고착 배경을 CSS 주석으로 명시)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (별도 이슈 없음 — 운영 중 직접 발견)

## 4️⃣. 스크린샷 (선택)

- 수정 전(Safari): 커버 워드마크·Q&A가 엔트런스 시작 blur 강도 그대로 고착
- 수정 후: blur-in 연출은 유지되고 최종 상태 선명

## 5️⃣. 리뷰 요구사항 (선택)

- filter 리스트 매칭으로 인한 시각 변화가 없는지 Chrome에서 커버/Q&A 엔트런스를 한 번 확인해 주세요.
- 유사 패턴 예방 관점: 이후 새 슬라이드에서 blur 엔트런스를 쓸 때 base에 filter가 있다면 리스트를 맞춰야 합니다 (CSS 주석으로 남김).

## 📎 참고 자료 (선택)

- CSS Filter Effects: 함수 리스트 불일치 시 discrete 전환 규칙 (interpolation of `<filter-value-list>`)
- 관련 PR: #47 (덱 프리로드 게이트 — blur 엔트런스 요소 will-change 도입, 이번 증상과는 무관 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)